### PR TITLE
fix(github-action): removed set-env command from github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,11 @@ jobs:
           if [ ${BRANCH} = "develop" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+       
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
           echo "TAG: ${CI_TAG}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,11 @@ jobs:
           if [ ${BRANCH} = "develop" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+       
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
           echo "TAG: ${CI_TAG}"
 


### PR DESCRIPTION
Signed-off-by: Rahul krishnan R A <rahulkrishnanfs@gmail.com>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
This PR is about to remove the deprecarted set-env command from the github action and fixes the issue #3 
**What this PR does?**:
Removed the deprecated set-env command from github action 
**Does this PR require any upgrade changes?**:
 No
**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Checklist:**
- [x] Fixes #3 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`: yes
- [ ] Has the change log section been updated? Not required 
- [ ] Commit has unit tests: No
- [ ] Commit has integration tests: No
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: Changes are not required 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: No Document changes required 

