### PR TITLE
feat(provisioner): allow using cluster ip for service

### DIFF
--- a/deploy/kubectl/busybox-openebs-rwx.yaml
+++ b/deploy/kubectl/busybox-openebs-rwx.yaml
@@ -35,7 +35,7 @@ spec:
           command:
             - sh
             - -c
-            - 'while true; do date > /mnt/data/index.html; hostname >> /mnt/data/index.html; sleep $(($RANDOM % 5 + 5)); done'
+            - 'while true; do touch /mnt/data/index.html; date >> /mnt/data/index.html; hostname >> /mnt/data/index.html; sleep $(($RANDOM % 5 + 5)); tail -1 /mnt/data/index.html; done'
           volumeMounts:
             - name: nfs-volume
               mountPath: /mnt/data

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -117,7 +117,9 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: OPENEBS_IO_ENABLE_ANALYTICS
-          value: "false"
+          value: "true"
+        - name: OPENEBS_IO_NFS_SERVER_USE_CLUSTERIP
+          value: "true"
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "openebs-operator-nfs"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
@@ -149,8 +151,8 @@ metadata:
     cas.openebs.io/config: |
       - name: NFSServerType
         value: "kernel"
-      - name: BackendStorageClass
-        value: "openebs-hostpath"
+      #- name: BackendStorageClass
+      #  value: "openebs-hostpath"
 provisioner: openebs.io/nfsrwx
 reclaimPolicy: Delete
 ---

--- a/pkg/kubernetes/api/apps/v1/deployment/deployment.go
+++ b/pkg/kubernetes/api/apps/v1/deployment/deployment.go
@@ -334,6 +334,11 @@ func (b *Builder) WithStrategyType(
 	return b
 }
 
+//WithStrategyTypeRecreate sets the strategy field of the deployment as Recreate
+func (b *Builder) WithStrategyTypeRecreate() *Builder {
+	return b.WithStrategyType(appsv1.RecreateDeploymentStrategyType)
+}
+
 // WithPodTemplateSpecBuilder sets the template field of the deployment
 func (b *Builder) WithPodTemplateSpecBuilder(
 	tmplbuilder *templatespec.Builder,

--- a/provisioner/env.go
+++ b/provisioner/env.go
@@ -36,6 +36,10 @@ const (
 	// ProvisionerExportsSC is the environment variable that provides the
 	// default storage class to be used for exports PVC mount used by NFS Server.
 	ProvisionerExportsSC menv.ENVKey = "OPENEBS_IO_EXPORTS_SC"
+
+	// ProvisionerNFSServerUseClusterIP is the environment variable that
+	// allows user to specify if ClusterIP should be used in NFS K8s Service
+	ProvisionerNFSServerUseClusterIP menv.ENVKey = "OPENEBS_IO_NFS_SERVER_USE_CLUSTERIP"
 )
 
 var (

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -197,6 +197,7 @@ func (p *Provisioner) createDeployment(nfsServerOpts *KernelNFSServerOptions) er
 		WithNamespace(p.namespace).
 		WithLabelsNew(nfsDeployLabelSelector).
 		WithSelectorMatchLabelsNew(nfsDeployLabelSelector).
+		WithStrategyTypeRecreate().
 		WithPodTemplateSpecBuilder(
 			pts.NewBuilder().
 				WithLabelsNew(nfsDeployLabelSelector).

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -427,7 +427,7 @@ func (p *Provisioner) getNFSServerAddress(nfsServerOpts *KernelNFSServerOptions)
 			WithNamespace(p.namespace).
 			Get(nfsServerOpts.serviceName, metav1.GetOptions{})
 		if err != nil || nfsService == nil {
-			return "", errors.Wrapf(err, "failed to get NFS Service for PVC{%v}", nfsServerOpts.serviceName)
+			return "", errors.Wrapf(err, "failed to get NFS Service for PVC{%v}", nfsServerOpts.pvcName)
 		}
 		return nfsService.Spec.ClusterIP, nil
 	}

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -420,6 +420,18 @@ func (p *Provisioner) getNFSServerAddress(nfsServerOpts *KernelNFSServerOptions)
 		return "", errors.Wrapf(err, "failed to create NFS Server for PVC{%v}", nfsServerOpts.pvName)
 	}
 
+	//Get the NFS Service to extract Cluster IP
+	if p.useClusterIP {
+		//nfsService := nil
+		nfsService, err := service.NewKubeClient().
+			WithNamespace(p.namespace).
+			Get(nfsServerOpts.serviceName, metav1.GetOptions{})
+		if err != nil || nfsService == nil {
+			return "", errors.Wrapf(err, "failed to get NFS Service for PVC{%v}", nfsServerOpts.serviceName)
+		}
+		return nfsService.Spec.ClusterIP, nil
+	}
+
 	// Return the cluster local nfs service ip
 	// <service-name>.<namespace>.svc.cluster.local
 	return nfsServerOpts.serviceName + "." + p.namespace + ".svc.cluster.local", nil

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -55,7 +55,7 @@ import (
 //  it with global information used across PV create and delete operations.
 func NewProvisioner(stopCh chan struct{}, kubeClient *clientset.Clientset) (*Provisioner, error) {
 
-	namespace := getOpenEBSNamespace() //menv.Get(menv.OpenEBSNamespace)
+	namespace := getOpenEBSNamespace()
 	if len(strings.TrimSpace(namespace)) == 0 {
 		return nil, fmt.Errorf("Cannot start Provisioner: failed to get namespace")
 	}
@@ -71,6 +71,7 @@ func NewProvisioner(stopCh chan struct{}, kubeClient *clientset.Clientset) (*Pro
 				Value: getDefaultNFSServerType(),
 			},
 		},
+		useClusterIP: menv.Truthy(ProvisionerNFSServerUseClusterIP),
 	}
 	p.getVolumeConfig = p.GetVolumeConfig
 

--- a/provisioner/provisioner_kernel_nfs_server.go
+++ b/provisioner/provisioner_kernel_nfs_server.go
@@ -81,6 +81,15 @@ func (p *Provisioner) ProvisionKernalNFSServer(opts pvController.ProvisionOption
 		WithMountOptions(opts.StorageClass.MountOptions).
 		WithNFS(nfsService, "/", false)
 
+	//Note: The nfs server is launched by the nfs-server-alpine.
+	//When "/" is replaced with "/nfsshare", the mount fails.
+	//
+	//Ref: https://github.com/sjiveson/nfs-server-alpine
+	//Due to the fsid=0 parameter set in the /etc/exports file,
+	//there's no need to specify the folder name when mounting from a client.
+	//For example, this works fine even though the folder being mounted and
+	//shared is /nfsshare
+
 	//Build the pvObject
 	pvObj, err := pvObjBuilder.Build()
 

--- a/provisioner/types.go
+++ b/provisioner/types.go
@@ -34,6 +34,8 @@ type Provisioner struct {
 	defaultConfig []mconfig.Config
 	// getVolumeConfig is a reference to a function
 	getVolumeConfig GetVolumeConfigFn
+	//determine if clusterIP or clusterDNS should be used
+	useClusterIP bool
 }
 
 //VolumeConfig struct contains the merged configuration of the PVC


### PR DESCRIPTION
Allow users to provide an option to either use Cluster DNS name or IP for the NFS Server. By default cluster local DNS name is used. This can be changed by setting the environment variable (OPENEBS_IO_NFS_SERVER_USE_CLUSTERIP=true) on the provisioner deployment.

In cases like #2, where DNS names can't be resolved, IP will work. 

Also fixes #6, to setup the nfs server deployment strategy to `recreate`. 

Signed-off-by: kmova <kiran.mova@mayadata.io>


