### PR TITLE
chore(build): Adding docker build for nfs-server image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,10 @@ before_script:
 
 script:
   - make provisioner-nfs-image PROVISIONER_NFS_IMAGE=provisioner-nfs-amd64
+  - make nfs-server-image NFS_SERVER_IMAGE=nfs-server-alpine-amd64
 
 after_success:
-  - make push PROVISIONER_NFS_IMAGE=provisioner-nfs-amd64
+  - make push PROVISIONER_NFS_IMAGE=provisioner-nfs-amd64 NFS_SERVER_IMAGE=nfs-server-alpine-amd64
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ PROVISIONER_NFS=provisioner-nfs
 # Once travis is deprecated, this field will be replaced by image name
 # used in Makefile.buildx.mk
 PROVISIONER_NFS_IMAGE?=provisioner-nfs-amd64
+NFS_SERVER_IMAGE?=nfs-server-alpine-amd64
 
 #Use this to build provisioner-nfs
 .PHONY: provisioner-nfs
@@ -165,6 +166,13 @@ provisioner-nfs-image: provisioner-nfs
 	@cd buildscripts/provisioner-nfs && docker build -t ${IMAGE_ORG}/${PROVISIONER_NFS_IMAGE}:${IMAGE_TAG} ${DBUILD_ARGS} . --no-cache
 	@rm buildscripts/provisioner-nfs/${PROVISIONER_NFS}
 
+.PHONY: nfs-server-image
+nfs-server-image:
+	@echo "----------------------------"
+	@echo "--> nfs-server image    "
+	@echo "----------------------------"
+	@cd nfs-server-container && docker build -t ${IMAGE_ORG}/${NFS_SERVER_IMAGE}:${IMAGE_TAG} . --no-cache
+
 .PHONY: license-check
 license-check:
 	@echo "--> Checking license header..."
@@ -182,6 +190,7 @@ license-check:
 .PHONY: push
 push:
 	DIMAGE=${IMAGE_ORG}/${PROVISIONER_NFS_IMAGE} ./buildscripts/push.sh
+	DIMAGE=${IMAGE_ORG}/${NFS_SERVER_IMAGE} ./buildscripts/push.sh
 
 # include the buildx recipes
 include Makefile.buildx.mk


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:


**What this PR does?**:
This PR adds a build target to build nfs-server docker image and push it to docker repo.
To build nfs-server image, run

`make nfs-server-image`

To push nfs-server image to repo, run
`make push`

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
