### PR TITLE
chore(image-name): Using multi-arch image for deployment

### DIFF
--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -90,7 +90,7 @@ spec:
       containers:
       - name: openebs-provisioner-nfs
         imagePullPolicy: IfNotPresent
-        image: openebs/provisioner-nfs-amd64:ci
+        image: openebs/provisioner-nfs:ci
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -205,7 +205,7 @@ func (p *Provisioner) createDeployment(nfsServerOpts *KernelNFSServerOptions) er
 				WithContainerBuildersNew(
 					container.NewBuilder().
 						WithName("nfs-server").
-						WithImage("openebs/nfs-server-alpine-amd64:ci").
+						WithImage("openebs/nfs-server-alpine:ci").
 						WithEnvsNew(
 							[]corev1.EnvVar{
 								{


### PR DESCRIPTION
Changes:
- Updating image name `openebs/provisioner-nfs-amd64` to `openebs/provisioner-nfs` in deployment example file(`deploy/kubectl/openebs-nfs-provisioner.yaml`
- Updating nfs-server deployment image  to `openebs/nfs-server-alpine` from `openebs/nfs-server-alpine-amd64`

Signed-off-by: mayank <mayank.patel@mayadata.io>
