### PR TITLE
fix(deploy): Fix liveness probe in nfs-provisioner deployment file

### DIFF
--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -137,7 +137,7 @@ spec:
             command:
             - sh
             - -c
-            - test `pgrep -c "^provisioner-nfs.*"` = 1
+            - test `pgrep "^provisioner-nfs.*"` = 1
           initialDelaySeconds: 30
           periodSeconds: 60
 ---


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Fixes https://github.com/openebs/dynamic-nfs-provisioner/issues/42

**What this PR does?**:
This PR fixes `pgrep` command option in liveness probe.

**Does this PR require any upgrade changes?**:
No

**Checklist:**
- [x] Fixes #42 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
