### PR TITLE
feat(nfs-server): Adding support to pass LeaseTime and GraceTime to nfs server

### DIFF
--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -157,6 +157,12 @@ metadata:
         value: "kernel"
       #- name: BackendStorageClass
       #  value: "openebs-hostpath"
+      #  LeaseTime defines the renewl period(in seconds) for client state
+      #- name: LeaseTime
+      #  value: 30
+      #  GraceTime defines the recovery period(in seconds) to reclaim locks
+      #- name: GraceTime
+      #  value: 30
 provisioner: openebs.io/nfsrwx
 reclaimPolicy: Delete
 ---

--- a/nfs-server-container/nfsd.sh
+++ b/nfs-server-container/nfsd.sh
@@ -31,6 +31,19 @@ stop()
   exit
 }
 
+get_nfs_args() {
+  declare -n args=$1
+
+  args=(--debug 8 --no-udp --no-nfs-version 2 --no-nfs-version 3)
+  if [ ! -z ${NFS_GRACE_TIME} ]; then
+    args+=( --grace-time ${NFS_GRACE_TIME})
+  fi
+
+  if [ ! -z ${NFS_LEASE_TIME} ]; then
+    args+=( --lease-time ${NFS_LEASE_TIME})
+  fi
+}
+
 # Check if the SHARED_DIRECTORY variable is empty
 if [ -z "${SHARED_DIRECTORY}" ]; then
   echo "The SHARED_DIRECTORY environment variable is unset or null, exiting..."
@@ -132,7 +145,8 @@ while true; do
     # /usr/sbin/rpc.statd
 
     echo "Starting NFS in the background..."
-    /usr/sbin/rpc.nfsd --debug 8 --no-udp --no-nfs-version 2 --no-nfs-version 3
+    get_nfs_args nfs_args
+    /usr/sbin/rpc.nfsd ${nfs_args[@]}
     echo "Exporting File System..."
     if /usr/sbin/exportfs -rv; then
       /usr/sbin/exportfs

--- a/provisioner/config.go
+++ b/provisioner/config.go
@@ -18,6 +18,7 @@ limitations under the License.
 package provisioner
 
 import (
+	"strconv"
 	"strings"
 
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -44,6 +45,14 @@ const (
 	//CustomServerConfig defines the server configuration to use,
 	// if it is set. Otherwise, use the default NFS server configuration.
 	CustomServerConfig = "CustomServerConfig"
+
+	// LeaseTime defines the renewl period(in seconds) for client state
+	// if not set then default value(90s) will be used
+	LeaseTime = "LeaseTime"
+
+	// GraceTime defines the recovery period(in seconds) to reclaim locks
+	// If it is not set then default value(90s) will be used
+	GraceTime = "GraceTime"
 )
 
 const (
@@ -130,6 +139,22 @@ func (c *VolumeConfig) GetCustomNFSServerConfig() string {
 		return ""
 	}
 	return customServerConfig
+}
+
+func (c *VolumeConfig) GetNFSServerLeaseTime() (int, error) {
+	leaseTime := c.getValue(LeaseTime)
+	if len(strings.TrimSpace(leaseTime)) == 0 {
+		return 0, nil
+	}
+	return strconv.Atoi(leaseTime)
+}
+
+func (c *VolumeConfig) GetNFServerGraceTime() (int, error) {
+	graceTime := c.getValue(GraceTime)
+	if len(strings.TrimSpace(graceTime)) == 0 {
+		return 0, nil
+	}
+	return strconv.Atoi(graceTime)
 }
 
 //getValue is a utility function to extract the value

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -17,6 +17,8 @@ limitations under the License.
 package provisioner
 
 import (
+	"strconv"
+
 	errors "github.com/pkg/errors"
 	"k8s.io/klog"
 
@@ -63,6 +65,14 @@ type KernelNFSServerOptions struct {
 	serviceName           string
 	deploymentName        string
 	nfsServerCustomConfig string
+
+	// leaseTime defines the renewl period(in seconds) for client state
+	// this should be in range from 10 to 3600 seconds
+	leaseTime int
+
+	// graceTime defines the recovery period(in seconds) to reclaim
+	// the locks and state
+	graceTime int
 }
 
 // validate checks that the required fields to create NFS Server
@@ -215,6 +225,14 @@ func (p *Provisioner) createDeployment(nfsServerOpts *KernelNFSServerOptions) er
 								{
 									Name:  "CUSTOM_EXPORTS_CONFIG",
 									Value: nfsServerOpts.nfsServerCustomConfig,
+								},
+								{
+									Name:  "NFS_LEASE_TIME",
+									Value: strconv.Itoa(nfsServerOpts.leaseTime),
+								},
+								{
+									Name:  "NFS_GRACE_TIME",
+									Value: strconv.Itoa(nfsServerOpts.graceTime),
 								},
 							},
 						).


### PR DESCRIPTION
Signed-off-by: mayank <mayank.patel@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR is to optimize the recovery time from nfs pod restart. Refer: https://github.com/openebs/dynamic-nfs-provisioner/issues/36

**What this PR does?**:
This PR adds support to pass lease-time and grace-time for nfs-server through storageclass. Storageclass can be configured with custom grace/lease time as below:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: openebs-rwx
  annotations:
    openebs.io/cas-type: nfsrwx
    cas.openebs.io/config: |
      - name: NFSServerType
        value: "kernel"
      #  LeaseTime defines the renewl period(in seconds) for client state
      - name: LeaseTime
        value: 50
      #  GraceTime defines the recovery period(in seconds) to reclaim locks
      - name: GraceTime
        value: 50
```

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:


**Checklist:**
- [x] Fixes #36 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
