### PR TITLE
fix(nfs-grace-period): use default 90s grace/lease period

### DIFF
--- a/nfs-server-container/nfsd.sh
+++ b/nfs-server-container/nfsd.sh
@@ -35,11 +35,13 @@ get_nfs_args() {
   declare -n args=$1
 
   args=(--debug 8 --no-udp --no-nfs-version 2 --no-nfs-version 3)
-  if [ ! -z ${NFS_GRACE_TIME} ]; then
+
+  # here we are checking if variable exist and its value is not null
+  if [ ! -z ${NFS_GRACE_TIME:+x} ]; then
     args+=( --grace-time ${NFS_GRACE_TIME})
   fi
 
-  if [ ! -z ${NFS_LEASE_TIME} ]; then
+  if [ ! -z ${NFS_LEASE_TIME:+x} ]; then
     args+=( --lease-time ${NFS_LEASE_TIME})
   fi
 }

--- a/provisioner/config.go
+++ b/provisioner/config.go
@@ -48,11 +48,13 @@ const (
 
 	// LeaseTime defines the renewl period(in seconds) for client state
 	// if not set then default value(90s) will be used
-	LeaseTime = "LeaseTime"
+	LeaseTime        = "LeaseTime"
+	DefaultLeaseTime = 90
 
 	// GraceTime defines the recovery period(in seconds) to reclaim locks
 	// If it is not set then default value(90s) will be used
-	GraceTime = "GraceTime"
+	GraceTime        = "GraceTime"
+	DefaultGraceTime = 90
 )
 
 const (
@@ -144,17 +146,33 @@ func (c *VolumeConfig) GetCustomNFSServerConfig() string {
 func (c *VolumeConfig) GetNFSServerLeaseTime() (int, error) {
 	leaseTime := c.getValue(LeaseTime)
 	if len(strings.TrimSpace(leaseTime)) == 0 {
-		return 0, nil
+		return DefaultLeaseTime, nil
 	}
-	return strconv.Atoi(leaseTime)
+	leaseTimeVal, err := strconv.Atoi(leaseTime)
+	if err != nil {
+		return 0, err
+	}
+	if leaseTimeVal == 0 {
+		leaseTimeVal = DefaultLeaseTime
+	}
+
+	return leaseTimeVal, nil
 }
 
 func (c *VolumeConfig) GetNFServerGraceTime() (int, error) {
 	graceTime := c.getValue(GraceTime)
 	if len(strings.TrimSpace(graceTime)) == 0 {
-		return 0, nil
+		return DefaultGraceTime, nil
 	}
-	return strconv.Atoi(graceTime)
+	graceTimeVal, err := strconv.Atoi(graceTime)
+	if err != nil {
+		return 0, err
+	}
+
+	if graceTimeVal == 0 {
+		graceTimeVal = DefaultGraceTime
+	}
+	return graceTimeVal, nil
 }
 
 //getValue is a utility function to extract the value


### PR DESCRIPTION
Signed-off-by: mayank <mayank.patel@mayadata.io>

**Why is this PR required? What issue does it fix?**:
- If lease/grace period is not set then nfs server deployments are created with grace/lease period `0` which disable the nfs server. This PR fixes this by using default grace/lease period 90 seconds.
- If existing nfs-deployment are updated with latest image then nfs-server pod went into CrashLoopBackOff state due to unbound error in nfsd.sh script. This PR also fixes this issue.

**What this PR does?**:
- This PR fixes the provisioner to use default values(90s) for lease/grace period.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Deployed nfs pvc with nfs storageclass having grace period and lease period set to 0
- Deployed nfs pvc with nfs storageclass without grace/lease time parameters
- Updated nfs-deployment by removing grace/lease time env variable(`NFS_LEASE_TIME` and `NFS_GRACE_TIME`)

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
