### PR TITLE
feat(metrics): Adding metrics for nfs-provisioner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/onsi/gomega v1.9.0
 	github.com/openebs/maya v1.12.1
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.17.3

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -67,7 +67,7 @@ var (
 		prometheus.CounterOpts{
 			Subsystem: NfsVolumeProvisionerSubsystem,
 			Name:      "persistentvolume_create_failed_total",
-			Help:      "Total number of apiserver requests failed",
+			Help:      "Total number of persistent volume creation failed attempts",
 		},
 		[]string{Process},
 	)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// NfsProvisionerSubsystem is prometheus subsystem name.
+	NfsVolumeProvisionerSubsystem = "nfs_volume_provisioner"
+
+	// Metrics
+	// ProvisionerRequestCreate represents metrics related to create resource request.
+	ProvisionerRequestCreate = "create"
+	// ProvisionerRequestDelete represents metrics related to delete resource request.
+	ProvisionerRequestDelete = "delete"
+
+	// Labels
+	Process = "process"
+)
+
+var (
+	// PersistentVolumeDeleteTotal is used to collect accumulated count of persistent volumes deleted.
+	PersistentVolumeDeleteTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: NfsVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_delete_total",
+			Help:      "Total number of persistent volumes deleted",
+		},
+		[]string{Process},
+	)
+	// PersistentVolumeDeleteFailedTotal is used to collect accumulated count of persistent volume delete failed attempts.
+	PersistentVolumeDeleteFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: NfsVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_delete_failed_total",
+			Help:      "Total number of persistent volume delete failed attempts",
+		},
+		[]string{Process},
+	)
+	// PersistentVolumeCreateTotal is used to collect accumulated count of persistent volume created.
+	PersistentVolumeCreateTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: NfsVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_create_total",
+			Help:      "Total number of persistent volumes created",
+		},
+		[]string{Process},
+	)
+	// PersistentVolumeCreateFailedTotal is used to collect accumulated count of persistent volume create requests failed.
+	PersistentVolumeCreateFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: NfsVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_create_failed_total",
+			Help:      "Total number of apiserver requests failed",
+		},
+		[]string{Process},
+	)
+)

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -41,12 +41,12 @@ import (
 	"k8s.io/klog"
 	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 
+	"github.com/openebs/dynamic-nfs-provisioner/pkg/metrics"
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 	analytics "github.com/openebs/maya/pkg/usage"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"github.com/openebs/dynamic-nfs-provisioner/pkg/metrics"
 
 	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"


### PR DESCRIPTION
Signed-off-by: mayank <mayank.patel@mayadata.io>

**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
This PR exposes metrics about nfs provisioning requests (create/delete). Following metrics are exposed:
```
persistentvolume_delete_total
persistentvolume_delete_failed_total
persistentvolume_create_total
persistentvolume_create_failed_total
```

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 