### PR TITLE
refactor(tests): remove maya dependency from sanity test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: v1.16.0
-          kubernetes version: v1.13.0
+          kubernetes version: v1.19.2
 
       - name: Install NFS utils
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,3 +208,36 @@ jobs:
           platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
           tags: |
             ${{ steps.docker_meta.outputs.tags }}
+
+  sanity-test:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
+    runs-on: ubuntu-latest
+    needs: ['provisioner-nfs', 'nfs-server']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.7
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.3.0
+        with:
+          minikube version: v1.16.0
+          kubernetes version: v1.13.0
+
+      - name: Install NFS utils
+        run: |
+          sudo apt-get update
+          sudo apt install nfs-common
+
+      - name: Installation
+        run: |
+          ./tests/install-localpv.sh
+          ./tests/install-nfs-provisioner.sh
+
+      - name: Running sanity tests
+        run: make sanity-test

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,10 @@ license-check:
 	@echo "--> Done checking license."
 	@echo
 
+.PHONY: sanity-test
+sanity-test: sanity-test
+	@echo "--> Running sanity test";
+	go test -v ./tests/...
 
 .PHONY: push
 push:

--- a/pkg/kubernetes/api/apps/v1/deployment/deployment.go
+++ b/pkg/kubernetes/api/apps/v1/deployment/deployment.go
@@ -15,7 +15,6 @@ package deployment
 
 import (
 	templatespec "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/podtemplatespec"
-	stringer "github.com/openebs/maya/pkg/apis/stringer/v1alpha1"
 	errors "github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,16 +62,6 @@ const (
 	// PredicateUpdateInProgress refer to predicate IsUpdateInProgress.
 	PredicateUpdateInProgress PredicateName = "UpdateInProgress"
 )
-
-// String implements the stringer interface
-func (d *Deploy) String() string {
-	return stringer.Yaml("deployment", d.object)
-}
-
-// GoString implements the goStringer interface
-func (d *Deploy) GoString() string {
-	return d.String()
-}
 
 // NewBuilder returns a new instance of builder meant for deployment
 func NewBuilder() *Builder {

--- a/pkg/kubernetes/api/core/v1/persistentvolumeclaim/build.go
+++ b/pkg/kubernetes/api/core/v1/persistentvolumeclaim/build.go
@@ -40,7 +40,7 @@ func BuildFrom(pvc *corev1.PersistentVolumeClaim) *Builder {
 		b := NewBuilder()
 		b.errs = append(
 			b.errs,
-			errors.New("failed to build cstorvolumeclaim object: nil pvc"),
+			errors.New("failed to build pvc object"),
 		)
 		return b
 	}

--- a/tests/install-localpv.sh
+++ b/tests/install-localpv.sh
@@ -39,7 +39,7 @@ function waitForDeployment() {
 			continue
 		fi
 
-		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o json | jq ".status.readyReplicas")
+		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o jsonpath='{.status.readyReplicas}')
 		if [ "$replicas" == "1" ]; then
 			break
 		else

--- a/tests/install-localpv.sh
+++ b/tests/install-localpv.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2021 The OpenEBS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkdir -p /tmp/openebs
+kubectl  apply -f https://raw.githubusercontent.com/openebs/dynamic-localpv-provisioner/v2.10.0/deploy/kubectl/provisioner-hostpath.yaml
+wget https://raw.githubusercontent.com/openebs/dynamic-localpv-provisioner/v2.10.0/deploy/kubectl/openebs-lite-sc.yaml -O /tmp/openebs-lite-sc.yaml
+sed -i  's/value\: \"\/var\/openebs\/local\/\"/value\: \"\/tmp\/openebs\/\"/' /tmp/openebs-lite-sc.yaml
+kubectl apply -f /tmp/openebs-lite-sc.yaml
+
+function waitForDeployment() {
+	DEPLOY=$1
+	NS=$2
+	CREATE=true
+
+	if [ $# -eq 3 ] && ! $3 ; then
+		CREATE=false
+	fi
+
+	for i in $(seq 1 50) ; do
+		kubectl get deployment -n ${NS} ${DEPLOY}
+		kstat=$?
+		if [ $kstat -ne 0 ] && ! $CREATE ; then
+			return
+		elif [ $kstat -eq 0 ] && ! $CREATE; then
+			sleep 3
+			continue
+		fi
+
+		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o json | jq ".status.readyReplicas")
+		if [ "$replicas" == "1" ]; then
+			break
+		else
+			echo "Waiting for ${DEPLOY} to be ready"
+			kubectl logs deploy/${DEPLOY} -n ${NS}
+			sleep 10
+		fi
+	done
+}
+
+waitForDeployment openebs-localpv-provisioner openebs
+

--- a/tests/install-nfs-provisioner.sh
+++ b/tests/install-nfs-provisioner.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2021 The OpenEBS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sed -i 's/#- name: BackendStorageClass/- name: BackendStorageClass/' deploy/kubectl/openebs-nfs-provisioner.yaml
+sed -i 's/#  value: "openebs-hostpath"/  value: "openebs-hostpath"/' deploy/kubectl/openebs-nfs-provisioner.yaml
+
+kubectl  apply -f deploy/kubectl/openebs-nfs-provisioner.yaml
+
+function waitForDeployment() {
+	DEPLOY=$1
+	NS=$2
+	CREATE=true
+
+	if [ $# -eq 3 ] && ! $3 ; then
+		CREATE=false
+	fi
+
+	for i in $(seq 1 50) ; do
+		kubectl get deployment -n ${NS} ${DEPLOY}
+		kstat=$?
+		if [ $kstat -ne 0 ] && ! $CREATE ; then
+			return
+		elif [ $kstat -eq 0 ] && ! $CREATE; then
+			sleep 3
+			continue
+		fi
+
+		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o json | jq ".status.readyReplicas")
+		if [ "$replicas" == "1" ]; then
+			break
+		else
+			echo "Waiting for ${DEPLOY} to be ready"
+			kubectl logs deploy/${DEPLOY} -n ${NS}
+			sleep 10
+		fi
+	done
+}
+
+waitForDeployment openebs-nfs-provisioner openebs
+kubectl get sc -o yaml

--- a/tests/install-nfs-provisioner.sh
+++ b/tests/install-nfs-provisioner.sh
@@ -38,7 +38,7 @@ function waitForDeployment() {
 			continue
 		fi
 
-		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o json | jq ".status.readyReplicas")
+		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o jsonpath='{.status.readyReplicas}')
 		if [ "$replicas" == "1" ]; then
 			break
 		else

--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2021 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// KubeClient interface for k8s API
+type KubeClient struct {
+	kubernetes.Interface
+}
+
+// Client for KubeClient
+var Client *KubeClient
+
+// getHomeDir gets the home directory for the system.
+// It is required to locate the .kube/config file
+func getHomeDir() (string, error) {
+	if h := os.Getenv("HOME"); h != "" {
+		return h, nil
+	}
+
+	return "", fmt.Errorf("not able to locate home directory")
+}
+
+// getConfigPath returns the filepath of kubeconfig file
+func getConfigPath() (string, error) {
+	home, err := getHomeDir()
+	if err != nil {
+		return "", err
+	}
+	kubeConfigPath := home + "/.kube/config"
+	return kubeConfigPath, nil
+}
+
+func initK8sClient(kubeConfigPath string) error {
+	var err error
+	if kubeConfigPath == "" {
+		kubeConfigPath, err = getConfigPath()
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil
+	}
+
+	Client = &KubeClient{client}
+	return nil
+}
+
+func (k *KubeClient) waitForPods(podNamespace, labelSelector string, expectedPhase corev1.PodPhase, expectedCount int) error {
+	dumpLog := 0
+	for {
+		podList, err := k.CoreV1().Pods(podNamespace).List(metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return err
+		}
+
+		count := 0
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == expectedPhase {
+				count++
+			}
+		}
+
+		if count == expectedCount {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+
+		if dumpLog > 6 {
+			fmt.Printf("checking for pod with labelSelector=%s in ns=%s, count=%d expectedCount=%d\n", labelSelector, podNamespace, count, expectedCount)
+			dumpLog = 0
+		}
+		dumpLog++
+	}
+	return nil
+}
+
+func (k *KubeClient) createNamespace(namespace string) error {
+	_, err := k.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			o := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			_, err = k.CoreV1().Namespaces().Create(o)
+		}
+	}
+	return err
+}
+
+// WaitForNamespaceCleanup wait for cleanup of the given namespace
+func (k *KubeClient) WaitForNamespaceCleanup(ns string) error {
+	dumpLog := 0
+	for {
+		_, err := k.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if dumpLog > 6 {
+			fmt.Printf("Waiting for cleanup of namespace %s\n", ns)
+			dumpLog = 0
+		}
+
+		dumpLog++
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (k *KubeClient) destroyNamespace(namespace string) error {
+	err := k.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return k.WaitForNamespaceCleanup(namespace)
+	}
+	return nil
+}
+
+func (k *KubeClient) waitForPVCBound(pvc, ns string) (corev1.PersistentVolumeClaimPhase, error) {
+	for {
+		o, err := k.CoreV1().
+			PersistentVolumeClaims(ns).
+			Get(pvc, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+
+		if o.Status.Phase == corev1.ClaimLost {
+			return o.Status.Phase, errors.Errorf("PVC %s/%s in lost state", ns, pvc)
+		}
+		if o.Status.Phase == corev1.ClaimBound {
+			return o.Status.Phase, nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (k *KubeClient) createPVC(pvc *corev1.PersistentVolumeClaim) error {
+	_, err := k.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	_, err = k.waitForPVCBound(pvc.Name, pvc.Namespace)
+	return err
+}
+
+func (k *KubeClient) deletePVC(namespace, pvc string) error {
+	err := k.CoreV1().PersistentVolumeClaims(namespace).Delete(pvc, &metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			err = nil
+		}
+	}
+
+	return err
+}
+
+func (k *KubeClient) createDeployment(deployment *appsv1.Deployment) error {
+	_, err := k.AppsV1().Deployments(deployment.Namespace).Create(deployment)
+	if err != nil {
+		return errors.Errorf("Failed to create deployment %s/%s, err=%s", deployment.Namespace, deployment.Name, err)
+	}
+	return nil
+}
+
+func (k *KubeClient) deleteDeployment(namespace, deployment string) error {
+	return k.AppsV1().Deployments(namespace).Delete(deployment, &metav1.DeleteOptions{})
+}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
- This PR refactor the sanity test and remove the maya repo dependency from it.
- Enabled sanity test execution in build workflow
- Added `sanity-test` target in Makefile. To execute sanity test, run `make sanity-test`

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 