### PR TITLE
fix(actions): skip release workflow on helm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ on:
   release:
     types:
       - 'created'
-    tags:
-      - 'v*'
 
 jobs:
   provisioner-nfs:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -101,6 +100,7 @@ jobs:
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   nfs-server:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR addresses the issue where a release workflow is triggered when a helm chart is released. The images pushed have tags with the name of the chart like [`nfs-provisioner-0.4.0`](https://github.com/openebs/dynamic-nfs-provisioner/actions/runs/942781288) in this case. We should avoid building images in such cases. The if condition added in the workflow prevents such workflows from executing.

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
