### PR TITLE
feat(node affinity): add support to specify node affinity rules of NFS Server

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for OpenEBS Dynamic NFS PV. For instructions to install 
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.1
+version: 0.4.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.4.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -128,6 +128,7 @@ helm install openebs-nfs openebs-nfs/nfs-provisioner --namespace openebs --creat
 | `nfsProvisioner.securityContext`      | Security context for container                | `""`                            |
 | `nfsProvisioner.tolerations`          | NFS Provisioner pod toleration values         | `""`                            |
 | `nfsProvisioner.nfsServerNamespace`          | NFS server namespace         | `"openebs"`                            |
+| `nfsProvisioner.nfsServerNodeAffinity`       | NFS Server node affinity rules                | `""`                          |
 | `nfsStorageClass.backendStorageClass` | StorageClass to be used to provision the backend volume. If not specified, the default StorageClass is used. | `""`                         |
 | `nfsStorageClass.isDefaultClass`      | Make 'openebs-kernel-nfs' the default StorageClass | `"false"`                         |
 | `nfsStorageClass.reclaimPolicy`       | ReclaimPolicy for NFS PVs                      | `"Delete"`                     |

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: OPENEBS_IO_NFS_SERVER_NS
               value: {{ .Values.nfsProvisioner.nfsServerNamespace }}
             {{- end }}
-            # OPENEBS_IO_NFS_SERVER_NODEAFFINITY defines the node affinity rules to place NFS Server
+            # OPENEBS_IO_NFS_SERVER_NODE_AFFINITY defines the node affinity rules to place NFS Server
             # instance. It accepts affinity rules in multiple ways:
             # - If NFS Server needs to be placed on storage nodes as well as only in
             #   zone-1 & zone-2 then value can be:
@@ -96,7 +96,7 @@ spec:
             #   value can be:
             #   value:  "kubernetes.io/storage-node,kubernetes.io/nfs-node"
             {{- if .Values.nfsProvisioner.nfsServerNodeAffinity }}
-            - name: OPENEBS_IO_NFS_SERVER_NODEAFFINITY
+            - name: OPENEBS_IO_NFS_SERVER_NODE_AFFINITY
               value: "{{ .Values.nfsProvisioner.nfsServerNodeAffinity }}"
             {{- end }}
           # Process name used for matching is limited to the 15 characters

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             #   value:  "kubernetes.io/zone:[zone-1,zone-2],kubernetes.io/storage-node".
             # - If NFS Server needs to be placed only on storage nodes & nfs nodes then
             #   value can be:
-            #   value:  "kubernetes.io/storage-node,kubernetes-nfs-node"
+            #   value:  "kubernetes.io/storage-node,kubernetes.io/nfs-node"
             {{- if .Values.nfsProvisioner.nfsServerNodeAffinity }}
             - name: OPENEBS_IO_NFS_SERVER_NODEAFFINITY
               value: "{{ .Values.nfsProvisioner.nfsServerNodeAffinity }}"

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -87,7 +87,18 @@ spec:
             - name: OPENEBS_IO_NFS_SERVER_NS
               value: {{ .Values.nfsProvisioner.nfsServerNamespace }}
             {{- end }}
-
+            # NODEAFFINITY defines the node affinity rules to place NFS Server
+            # instance. It accepts affinity rules in multiple ways:
+            # - If NFS Server needs to be placed on storage nodes as well as only in
+            #   zone-1 & zone-2 then value can be:
+            #   value:  "kubernetes.io/zone:[zone-1,zone-2],kubernetes.io/storage-node".
+            # - If NFS Server needs to be placed only on storage nodes & nfs nodes then
+            #   value can be:
+            #   value:  "kubernetes.io/storage-node,kubernetes-nfs-node"
+            {{- if .Values.nfsProvisioner.nfsServerNodeAffinity }}
+            - name: NODEAFFINITY
+              value: "{{ .Values.nfsProvisioner.nfsServerNodeAffinity }}"
+            {{- end }}
           # Process name used for matching is limited to the 15 characters
           # present in the pgrep output.
           # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             - name: OPENEBS_IO_NFS_SERVER_NS
               value: {{ .Values.nfsProvisioner.nfsServerNamespace }}
             {{- end }}
-            # NODEAFFINITY defines the node affinity rules to place NFS Server
+            # OPENEBS_IO_NFS_SERVER_NODEAFFINITY defines the node affinity rules to place NFS Server
             # instance. It accepts affinity rules in multiple ways:
             # - If NFS Server needs to be placed on storage nodes as well as only in
             #   zone-1 & zone-2 then value can be:
@@ -96,7 +96,7 @@ spec:
             #   value can be:
             #   value:  "kubernetes.io/storage-node,kubernetes-nfs-node"
             {{- if .Values.nfsProvisioner.nfsServerNodeAffinity }}
-            - name: NODEAFFINITY
+            - name: OPENEBS_IO_NFS_SERVER_NODEAFFINITY
               value: "{{ .Values.nfsProvisioner.nfsServerNodeAffinity }}"
             {{- end }}
           # Process name used for matching is limited to the 15 characters

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -66,9 +66,17 @@ nfsProvisioner:
   healthCheck:
     initialDelaySeconds: 30
     periodSeconds: 60
- # namespace in which nfs server objects should be created
- # By default, nfs provisioner will create these resources in nfs provisioner's namespace
- # nfsServerNamespace: openebs
+  # namespace in which nfs server objects should be created
+  # By default, nfs provisioner will create these resources in nfs provisioner's namespace
+  # nfsServerNamespace: openebs
+  #
+  # nfsServerNodeAffinity defines the node affinity rules to place NFS Server
+  # instance. It accepts affinity rules in multiple ways:
+  # - If NFS Server needs to be placed on storage nodes as well as only in
+  #   zone-1 & zone-2 then value can be: "kubernetes.io/zone:[zone-1,zone-2],kubernetes.io/storage-node".
+  # - If NFS Server needs to be placed only on storage nodes & nfs nodes then
+  #   value can be: "kubernetes.io/storage-node,kubernetes.io/nfs-node"
+  # nfsServerNodeAffinity: "kubernetes.io/storage-node,kubernetes.io/nfs-node"
 
 nfsStorageClass:
   name: openebs-kernel-nfs

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -92,16 +92,26 @@ spec:
         imagePullPolicy: IfNotPresent
         image: openebs/provisioner-nfs:ci
         env:
-        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
-        # based on this address. This is ignored if empty.
-        # This is supported for openebs provisioner version 0.5.2 onwards
-        #- name: OPENEBS_IO_K8S_MASTER
-        #  value: "http://10.128.0.12:8080"
-        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
-        # based on this config. This is ignored if empty.
-        # This is supported for openebs provisioner version 0.5.2 onwards
-        #- name: OPENEBS_IO_KUBE_CONFIG
-        #  value: "/home/ubuntu/.kube/config"
+        #   OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        #   based on this address. This is ignored if empty.
+        #   This is supported for openebs provisioner version 0.5.2 onwards
+        # - name: OPENEBS_IO_K8S_MASTER
+        #   value: "http://10.128.0.12:8080"
+        #   OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        #   based on this config. This is ignored if empty.
+        #   This is supported for openebs provisioner version 0.5.2 onwards
+        # - name: OPENEBS_IO_KUBE_CONFIG
+        #   value: "/home/ubuntu/.kube/config"
+        #   NODEAFFINITY defines the node affinity rules to place NFS Server
+        #   instance. It accepts affinity rules in multiple ways:
+        #   - If NFS Server needs to be placed on storage nodes as well as only in
+        #     zone-1 & zone-2 then value can be:
+        #     value:  "kubernetes.io/zone:[zone-1,zone-2],kubernetes.io/storage-node".
+        #   - If NFS Server needs to be placed only on storage nodes & nfs nodes then
+        #     value can be:
+        #     value:  "kubernetes.io/storage-node,kubernetes-nfs-node"
+        # - name: NODEAFFINITY
+        #   value: "kubernetes.io/storage-node,kubernetes.io/nfs-node"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -102,7 +102,7 @@ spec:
         #   This is supported for openebs provisioner version 0.5.2 onwards
         # - name: OPENEBS_IO_KUBE_CONFIG
         #   value: "/home/ubuntu/.kube/config"
-        #   OPENEBS_IO_NFS_SERVER_NODEAFFINITY defines the node affinity rules to place NFS Server
+        #   OPENEBS_IO_NFS_SERVER_NODE_AFFINITY defines the node affinity rules to place NFS Server
         #   instance. It accepts affinity rules in multiple ways:
         #   - If NFS Server needs to be placed on storage nodes as well as only in
         #     zone-1 & zone-2 then value can be:
@@ -110,7 +110,7 @@ spec:
         #   - If NFS Server needs to be placed only on storage nodes & nfs nodes then
         #     value can be:
         #     value:  "kubernetes.io/storage-node,kubernetes.io/nfs-node"
-        # - name: OPENEBS_IO_NFS_SERVER_NODEAFFINITY
+        # - name: OPENEBS_IO_NFS_SERVER_NODE_AFFINITY
         #   value: "kubernetes.io/storage-node,kubernetes.io/nfs-node"
         - name: NODE_NAME
           valueFrom:

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -102,7 +102,7 @@ spec:
         #   This is supported for openebs provisioner version 0.5.2 onwards
         # - name: OPENEBS_IO_KUBE_CONFIG
         #   value: "/home/ubuntu/.kube/config"
-        #   NODEAFFINITY defines the node affinity rules to place NFS Server
+        #   OPENEBS_IO_NFS_SERVER_NODEAFFINITY defines the node affinity rules to place NFS Server
         #   instance. It accepts affinity rules in multiple ways:
         #   - If NFS Server needs to be placed on storage nodes as well as only in
         #     zone-1 & zone-2 then value can be:
@@ -110,7 +110,7 @@ spec:
         #   - If NFS Server needs to be placed only on storage nodes & nfs nodes then
         #     value can be:
         #     value:  "kubernetes.io/storage-node,kubernetes-nfs-node"
-        # - name: NODEAFFINITY
+        # - name: OPENEBS_IO_NFS_SERVER_NODEAFFINITY
         #   value: "kubernetes.io/storage-node,kubernetes.io/nfs-node"
         - name: NODE_NAME
           valueFrom:

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -109,7 +109,7 @@ spec:
         #     value:  "kubernetes.io/zone:[zone-1,zone-2],kubernetes.io/storage-node".
         #   - If NFS Server needs to be placed only on storage nodes & nfs nodes then
         #     value can be:
-        #     value:  "kubernetes.io/storage-node,kubernetes-nfs-node"
+        #     value:  "kubernetes.io/storage-node,kubernetes.io/nfs-node"
         # - name: OPENEBS_IO_NFS_SERVER_NODEAFFINITY
         #   value: "kubernetes.io/storage-node,kubernetes.io/nfs-node"
         - name: NODE_NAME

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -158,8 +158,8 @@ metadata:
     cas.openebs.io/config: |
       - name: NFSServerType
         value: "kernel"
-      #- name: BackendStorageClass
-      #  value: "openebs-hostpath"
+      - name: BackendStorageClass
+        value: "openebs-hostpath"
       #  LeaseTime defines the renewl period(in seconds) for client state
       #- name: LeaseTime
       #  value: 30

--- a/go.mod
+++ b/go.mod
@@ -41,5 +41,6 @@ require (
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/kubernetes v1.17.3
 	sigs.k8s.io/sig-storage-lib-external-provisioner v4.1.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -860,6 +860,7 @@ k8s.io/kube-proxy v0.17.3/go.mod h1:ds8R8bUYPWtQlspC47Sff7o5aQhWDsv6jpQJATDuqaQ=
 k8s.io/kube-scheduler v0.17.3/go.mod h1:36HgrrPqzK+rOLTRtDG//b89KjrAZqFI4PXOpdH351M=
 k8s.io/kubectl v0.17.3/go.mod h1:NUn4IBY7f7yCMwSop2HCXlw/MVYP4HJBiUmOR3n9w28=
 k8s.io/kubelet v0.17.3/go.mod h1:Nh8owUHZcUXtnDAtmGnip36Nw+X6c4rbmDQlVyIhwMQ=
+k8s.io/kubernetes v1.17.3 h1:zWCppkLfHM+hoLqfbsrQ0cJnYw+4vAvedI92oQnjo/Q=
 k8s.io/kubernetes v1.17.3/go.mod h1:gt28rfzaskIzJ8d82TSJmGrJ0XZD0BBy8TcQvTuCI3w=
 k8s.io/legacy-cloud-providers v0.17.3/go.mod h1:ujZML5v8efVQxiXXTG+nck7SjP8KhMRjUYNIsoSkYI0=
 k8s.io/metrics v0.17.3/go.mod h1:HEJGy1fhHOjHggW9rMDBJBD3YuGroH3Y1pnIRw9FFaI=

--- a/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
+++ b/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
@@ -304,6 +304,7 @@ func (b *Builder) WithNodeAffinityMatchExpressions(
 			NodeAffinity.
 			RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
 	}
+
 	b.podtemplatespec.
 		Object.
 		Spec.

--- a/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
+++ b/pkg/kubernetes/api/core/v1/podtemplatespec/podtemplatespec.go
@@ -273,6 +273,57 @@ func (b *Builder) WithAffinity(affinity *corev1.Affinity) *Builder {
 	return b
 }
 
+// WithNodeAffinityMatchExpressions sets matchexpressions under
+// nodeAffinity
+// NOTE: If nil is passed then match expressions will not be
+//		 propogated to node affinity.
+// CAUTION: Don't invoke WithAffinity func after calling this function
+//			It will overwrite MatchExpression
+func (b *Builder) WithNodeAffinityMatchExpressions(
+	mExpressions []corev1.NodeSelectorRequirement) *Builder {
+	if len(mExpressions) == 0 {
+		return b
+	}
+
+	if b.podtemplatespec.Object.Spec.Affinity == nil {
+		b.podtemplatespec.Object.Spec.Affinity = &corev1.Affinity{}
+	}
+	if b.podtemplatespec.Object.Spec.Affinity.NodeAffinity == nil {
+		b.podtemplatespec.Object.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if b.podtemplatespec.
+		Object.
+		Spec.
+		Affinity.
+		NodeAffinity.
+		RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		b.podtemplatespec.
+			Object.
+			Spec.
+			Affinity.
+			NodeAffinity.
+			RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	b.podtemplatespec.
+		Object.
+		Spec.
+		Affinity.
+		NodeAffinity.
+		RequiredDuringSchedulingIgnoredDuringExecution.
+		NodeSelectorTerms = append(b.podtemplatespec.
+		Object.
+		Spec.
+		Affinity.
+		NodeAffinity.
+		RequiredDuringSchedulingIgnoredDuringExecution.
+		NodeSelectorTerms,
+		corev1.NodeSelectorTerm{
+			MatchExpressions: mExpressions,
+		},
+	)
+	return b
+}
+
 // WithTolerationsByValue sets pod toleration.
 // If provided tolerations argument is empty it does not complain.
 func (b *Builder) WithTolerationsByValue(tolerations ...corev1.Toleration) *Builder {

--- a/provisioner/env.go
+++ b/provisioner/env.go
@@ -17,6 +17,9 @@ limitations under the License.
 package provisioner
 
 import (
+	"os"
+	"strings"
+
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
@@ -51,6 +54,9 @@ const (
 	// NFSServerNamespace defines the namespace for nfs server objects
 	// Default value is menv.OpenEBSNamespace(operator namespace)
 	NFSServerNamespace menv.ENVKey = "OPENEBS_IO_NFS_SERVER_NS"
+
+	// NODEAFFINITYKEY holds the env name representing Node affinity rules
+	NODEAFFINITYKEY = "NODEAFFINITY"
 )
 
 var (
@@ -86,4 +92,9 @@ func getOpenEBSServiceAccountName() string {
 
 func getNFSServerImage() string {
 	return menv.GetOrDefault(NFSServerImageKey, string(NFSServerDefaultImage))
+}
+
+// getEnv fetches the provided environment variable's value
+func getEnv(envKey string) (value string) {
+	return strings.TrimSpace(os.Getenv(envKey))
 }

--- a/provisioner/env.go
+++ b/provisioner/env.go
@@ -56,7 +56,7 @@ const (
 	NFSServerNamespace menv.ENVKey = "OPENEBS_IO_NFS_SERVER_NS"
 
 	// NODEAFFINITYKEY holds the env name representing Node affinity rules
-	NODEAFFINITYKEY = "NODEAFFINITY"
+	NODEAFFINITYKEY = "OPENEBS_IO_NFS_SERVER_NODEAFFINITY"
 )
 
 var (

--- a/provisioner/env.go
+++ b/provisioner/env.go
@@ -17,9 +17,6 @@ limitations under the License.
 package provisioner
 
 import (
-	"os"
-	"strings"
-
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
@@ -55,8 +52,8 @@ const (
 	// Default value is menv.OpenEBSNamespace(operator namespace)
 	NFSServerNamespace menv.ENVKey = "OPENEBS_IO_NFS_SERVER_NS"
 
-	// NODEAFFINITYKEY holds the env name representing Node affinity rules
-	NODEAFFINITYKEY = "OPENEBS_IO_NFS_SERVER_NODEAFFINITY"
+	// NodeAffinityKey holds the env name representing Node affinity rules
+	NodeAffinityKey menv.ENVKey = "OPENEBS_IO_NFS_SERVER_NODE_AFFINITY"
 )
 
 var (
@@ -94,7 +91,6 @@ func getNFSServerImage() string {
 	return menv.GetOrDefault(NFSServerImageKey, string(NFSServerDefaultImage))
 }
 
-// getEnv fetches the provided environment variable's value
-func getEnv(envKey string) (value string) {
-	return strings.TrimSpace(os.Getenv(envKey))
+func getNfsServerNodeAffinity() string {
+	return menv.Get(NodeAffinityKey)
 }

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -217,6 +217,7 @@ func (p *Provisioner) createDeployment(nfsServerOpts *KernelNFSServerOptions) er
 				WithSecurityContext(&corev1.PodSecurityContext{
 					FSGroup: nfsServerOpts.fsGroup,
 				}).
+				WithNodeAffinityMatchExpressions(p.nodeAffinity.MatchExpressions).
 				WithContainerBuildersNew(
 					container.NewBuilder().
 						WithName("nfs-server").

--- a/provisioner/node_affinity.go
+++ b/provisioner/node_affinity.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The OpenEBS Authors.
+Copyright 2021 The OpenEBS Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,38 +17,102 @@ limitations under the License.
 package provisioner
 
 import (
-	"os"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
-
-var (
-	nodeAffinityKey = "NODEAFFINITY"
-)
-
-// getEnv fetches the provided environment variable's value
-func getEnv(envKey string) (value string) {
-	return strings.TrimSpace(os.Getenv(envKey))
-}
 
 // getNodeAffinityRules fetchs node affinity rules from
 // environment value
 func getNodeAffinityRules() NodeAffinity {
 	var nodeAffinity NodeAffinity
 
-	affinityValue := getEnv(nodeAffinityKey)
+	affinityValue := getEnv(NODEAFFINITYKEY)
 	if affinityValue == "" {
 		return nodeAffinity
 	}
 
 	rules := strings.Split(affinityValue, "],")
-	nodeAffinity.MatchExpressions = make([]corev1.NodeSelectorRequirement, len(rules))
-	for index, rule := range rules {
-		nodeAffinity.MatchExpressions[index] = getNodeSelectorRequirement(rule)
+	for _, rule := range rules {
+		nodeAffinity.MatchExpressions = append(nodeAffinity.MatchExpressions, getOneOrMoreNodeSelectorRequirements(rule)...)
 	}
 
 	return nodeAffinity
+}
+
+// getOneOrMoreNodeSelectorRequirements can take one or more node affinity requirements
+// as string and convert them to structured form of Requirements
+// Ex:
+//	  Case1 - Input argument: kubernetes.io/storage-node,kubernetes.io/nfs-node,kubernetes.io/zone:[zone-1,zone-2,zone-3]
+//
+//	  Return value:
+//		- key: kubernetes.io/storage-node
+//		  operator: Exists
+//		- key: kubernetes.io/nfs-node
+//		  operator: Exists
+//		- key: kubernetes.io/zone
+//		  operator: In
+//		  values:
+//		  - zone-1
+//		  - zone-2
+//		  - zone-3
+//
+//    Case2 - Input argument: kubernetes.io/storage-node,kubernetes.io/nfs-node,kubernetes.io/linux-amd64
+//
+//    Return value:
+//		- key: kubernetes.io/storage-node
+//		  operator: Exists
+//		- key: kubernetes.io/nfs-node
+//		  operator: Exists
+//		- key: kubernetes.io/linux-amd64
+//		  operator: Exists
+//
+//    Case3 - Input argument: kubernetes.io/zone:[zone-1,zone-2]
+//
+//    Return value:
+//		- key: kubernetes.io/zone
+//		  operator: In
+//		  values:
+//		  - zone-1
+//		  - zone-2
+func getOneOrMoreNodeSelectorRequirements(
+	requirementsAsValue string) []corev1.NodeSelectorRequirement {
+	var nodeRequirements []corev1.NodeSelectorRequirement
+	var complexReq corev1.NodeSelectorRequirement
+	// isComplexRequirement will be true when input is: <key1>,<key2>,<key3>:[value1, value2]
+	// NOTE: Valued key-value pair will be always at end
+	isComplexRequirement := regexp.MustCompile(`.*,+.*:\[.*`).FindString(requirementsAsValue) != ""
+
+	if isComplexRequirement {
+		matchingString := getRightMostMatchingString(regexp.MustCompile(`,.*:\[.*`), requirementsAsValue)
+		// If input argument is Case 1
+		if matchingString != "" {
+			matchingIndex := strings.LastIndex(requirementsAsValue, matchingString)
+			complexReq = getNodeSelectorRequirement(requirementsAsValue[matchingIndex:])
+			requirementsAsValue = requirementsAsValue[:matchingIndex]
+		}
+	}
+
+	// After processing complex now we will left with two cases
+	// C1: <key1>,<key2>
+	// C2: <key3>:[value2] --- Original Case3
+	if strings.ContainsRune(requirementsAsValue, rune('[')) {
+		// Case3
+		nodeRequirements = append(nodeRequirements, getNodeSelectorRequirement(requirementsAsValue))
+	} else {
+		// Case2
+		for _, req := range strings.Split(requirementsAsValue, ",") {
+			if strings.TrimSpace(req) != "" {
+				nodeRequirements = append(nodeRequirements, getNodeSelectorRequirement(req))
+			}
+		}
+		if isComplexRequirement {
+			nodeRequirements = append(nodeRequirements, complexReq)
+		}
+	}
+
+	return nodeRequirements
 }
 
 // getNodeSelectorRequirement converts requirement from plain
@@ -62,6 +126,19 @@ func getNodeAffinityRules() NodeAffinity {
 //			- z1-host1
 //			- z2-host1
 //			- z3-host1
+//
+// Example: kubernetes.io/hostName:[region-1,region-2 value convert as below
+//
+//			key: kubernetes.io/hostName
+//			operator: "In"
+//			values:
+//			- region-1
+//			- region-2
+//
+// Example: kubernetes.io/storage-node
+//
+//			key: kubernetes.io/storage-node
+//			operator: "Exists"
 func getNodeSelectorRequirement(reqAsValue string) corev1.NodeSelectorRequirement {
 	var nsRequirement corev1.NodeSelectorRequirement
 	keyValues := strings.Split(reqAsValue, ":")
@@ -87,4 +164,31 @@ func getNodeSelectorRequirement(reqAsValue string) corev1.NodeSelectorRequiremen
 	}
 
 	return nsRequirement
+}
+
+// getRightMostMatchingString will return right must matching string
+// which satisfies given pattern
+// Example:
+//	- Fetch last pattern matching on string
+//		Pattern: {,.*:\[.*} string: "key1,key2,key3:[v1, v2, v3]"
+//		Return value: key3:[v1, v2, v3]
+func getRightMostMatchingString(regex *regexp.Regexp, value string) string {
+	loc := regex.FindStringIndex(value)
+	if len(loc) == 0 {
+		// given value is not satisfying regular expression
+		return ""
+	}
+	value = value[loc[0]:]
+	if value[0] == ',' && len(value) > 1 {
+		value = value[1:]
+	}
+	rightMostMatchingString := getRightMostMatchingString(regex, value)
+
+	// If substring matching to regular expression is found then return
+	// right most index
+	if rightMostMatchingString != "" {
+		return rightMostMatchingString
+	}
+	// else return starting location
+	return value
 }

--- a/provisioner/node_affinity.go
+++ b/provisioner/node_affinity.go
@@ -28,7 +28,7 @@ import (
 func getNodeAffinityRules() NodeAffinity {
 	var nodeAffinity NodeAffinity
 
-	affinityValue := getEnv(NODEAFFINITYKEY)
+	affinityValue := getNfsServerNodeAffinity()
 	if affinityValue == "" {
 		return nodeAffinity
 	}

--- a/provisioner/node_affinity.go
+++ b/provisioner/node_affinity.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	nodeAffinityKey = "NODEAFFINITY"
+)
+
+// getEnv fetches the provided environment variable's value
+func getEnv(envKey string) (value string) {
+	return strings.TrimSpace(os.Getenv(envKey))
+}
+
+// getNodeAffinityRules fetchs node affinity rules from
+// environment value
+func getNodeAffinityRules() NodeAffinity {
+	var nodeAffinity NodeAffinity
+
+	affinityValue := getEnv(nodeAffinityKey)
+	if affinityValue == "" {
+		return nodeAffinity
+	}
+
+	rules := strings.Split(affinityValue, "],")
+	nodeAffinity.MatchExpressions = make([]corev1.NodeSelectorRequirement, len(rules))
+	for index, rule := range rules {
+		nodeAffinity.MatchExpressions[index] = getNodeSelectorRequirement(rule)
+	}
+
+	return nodeAffinity
+}
+
+// getNodeSelectorRequirement converts requirement from plain
+// string to corev1.NodeSelectorRequirement
+//
+// Example: kubernetes.io/hostName:[z1-host1,z2-host1,z3-host1] value convert as below
+//
+//			key: kubernetes.io/hostName
+//			operator: "In"
+//			values:
+//			- z1-host1
+//			- z2-host1
+//			- z3-host1
+func getNodeSelectorRequirement(reqAsValue string) corev1.NodeSelectorRequirement {
+	var nsRequirement corev1.NodeSelectorRequirement
+	keyValues := strings.Split(reqAsValue, ":")
+	// Key will always exist in given ENV
+	nsRequirement.Key = strings.TrimSpace(keyValues[0])
+	nsRequirement.Operator = corev1.NodeSelectorOpExists
+
+	// If there exist more than one value
+	if len(keyValues) > 1 {
+		valueList := strings.Split(
+			strings.TrimSpace(
+				strings.TrimLeft(
+					strings.TrimRight(keyValues[1], "]"),
+					"["),
+			),
+			",")
+
+		// If user mentioned list of values
+		if len(valueList) > 1 || (len(valueList) == 1 && strings.TrimSpace(valueList[0]) != "") {
+			nsRequirement.Operator = corev1.NodeSelectorOpIn
+			nsRequirement.Values = valueList
+		}
+	}
+
+	return nsRequirement
+}

--- a/provisioner/node_affinity_test.go
+++ b/provisioner/node_affinity_test.go
@@ -160,7 +160,7 @@ func TestGetNodeAffinityRules(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		os.Setenv(NODEAFFINITYKEY, test.envValue)
+		os.Setenv(string(NodeAffinityKey), test.envValue)
 		gotNodeAffinityRules := getNodeAffinityRules()
 		if !reflect.DeepEqual(gotNodeAffinityRules.MatchExpressions, test.expectedAffinity.MatchExpressions) {
 			t.Errorf(
@@ -171,7 +171,7 @@ func TestGetNodeAffinityRules(t *testing.T) {
 			)
 		}
 
-		os.Unsetenv(NODEAFFINITYKEY)
+		os.Unsetenv(string(NodeAffinityKey))
 	}
 }
 

--- a/provisioner/node_affinity_test.go
+++ b/provisioner/node_affinity_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2021 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetNodeAffinityRules(t *testing.T) {
+	tests := map[string]struct {
+		envValue         string
+		expectedAffinity NodeAffinity
+	}{
+		"when there is only single topology without values": {
+			envValue: "kubernetes.io/storage-node:[]",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		"when there are multiple topologies with values": {
+			envValue: "kubernetes.io/storage-node:[],kubernetes.io/zone:[zone-a,zone-b,zone-c]," +
+				"kubernetes.io/region:[region-1],kubernetes.io/nfs-node:[]",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/zone",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"zone-a", "zone-b", "zone-c"},
+					},
+					{
+						Key:      "kubernetes.io/region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"region-1"},
+					},
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		"when there are multiple topologies without values": {
+			envValue: "kubernetes.io/storage-node:[],kubernetes.io/nfs-node:[]",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		"when there are multiple topologies without values & []": {
+			envValue: "kubernetes.io/storage-node ,kubernetes.io/nfs-node",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		"when there are multiple topologies without empty values([])": {
+			envValue: "kubernetes.io/nfs-node,kubernetes.io/storage-node,kubernetes.io/zone:[zone-a,zone-b,zone-c]," +
+				"kubernetes.io/region:[region-1],kubernetes.io/nfs-node",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/zone",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"zone-a", "zone-b", "zone-c"},
+					},
+					{
+						Key:      "kubernetes.io/region",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"region-1"},
+					},
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		"when there are multiple topologies without values but one of them has empty": {
+			envValue: "kubernetes.io/storage-node,kubernetes.io/nfs-node:[]",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+		"when there are multiple topologies with empty and without values": {
+			envValue: "kubernetes.io/storage-node:[],kubernetes.io/nfs-node",
+			expectedAffinity: NodeAffinity{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "kubernetes.io/storage-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+					{
+						Key:      "kubernetes.io/nfs-node",
+						Operator: corev1.NodeSelectorOpExists,
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		os.Setenv(NODEAFFINITYKEY, test.envValue)
+		gotNodeAffinityRules := getNodeAffinityRules()
+		if !reflect.DeepEqual(gotNodeAffinityRules.MatchExpressions, test.expectedAffinity.MatchExpressions) {
+			t.Errorf(
+				"%q test got failed expected %v but got %v",
+				name,
+				test.expectedAffinity.MatchExpressions,
+				gotNodeAffinityRules.MatchExpressions,
+			)
+		}
+
+		os.Unsetenv(NODEAFFINITYKEY)
+	}
+}
+
+func TestGetRightMostMatchingIndex(t *testing.T) {
+	tests := map[string]struct {
+		regexp         *regexp.Regexp
+		str            string
+		expectedString string
+	}{
+		"When repitative pattern exist twice": {
+			regexp:         regexp.MustCompile(`,+.*:\[.*`),
+			str:            "key1,key2,key3:[v1,v2,v3]",
+			expectedString: "key3:[v1,v2,v3]",
+		},
+		"When pattern exist exactly once": {
+			regexp:         regexp.MustCompile(`,+.*:\[.*`),
+			str:            ",key3:[v1,v2,v3]",
+			expectedString: "key3:[v1,v2,v3]",
+		},
+		"When pattern matches more than twice": {
+			regexp:         regexp.MustCompile(`,+.*:\[.*`),
+			str:            "key1,key2,key3,key4:[v1,v2]",
+			expectedString: "key4:[v1,v2]",
+		},
+		"When pattern does not match with given string": {
+			regexp:         regexp.MustCompile(`abcd`),
+			str:            "openebs",
+			expectedString: "",
+		},
+	}
+	for name, test := range tests {
+		name := name
+		test := test
+		t.Run(name, func(t *testing.T) {
+			gotString := getRightMostMatchingString(test.regexp, test.str)
+			if gotString != test.expectedString {
+				t.Errorf("%q test failed expected: %q but got %q", name, test.expectedString, gotString)
+			}
+		})
+	}
+}

--- a/provisioner/types.go
+++ b/provisioner/types.go
@@ -19,8 +19,9 @@ package provisioner
 
 import (
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	listerv1 "k8s.io/client-go/listers/core/v1"
 )
 
 //Provisioner struct has the configuration and utilities required
@@ -47,6 +48,12 @@ type Provisioner struct {
 
 	//determine if clusterIP or clusterDNS should be used
 	useClusterIP bool
+
+	// k8sNodeLister hold cache information about nodes
+	k8sNodeLister listerv1.NodeLister
+
+	// nodeAffinity specifies requirements for scheduling NFS Server
+	nodeAffinity NodeAffinity
 }
 
 //VolumeConfig struct contains the merged configuration of the PVC
@@ -72,4 +79,63 @@ type VolumeConfig struct {
 
 // GetVolumeConfigFn allows to plugin a custom function
 //  and makes it easy to unit test provisioner
-type GetVolumeConfigFn func(pvName string, pvc *v1.PersistentVolumeClaim) (*VolumeConfig, error)
+type GetVolumeConfigFn func(pvName string, pvc *corev1.PersistentVolumeClaim) (*VolumeConfig, error)
+
+// NodeAffinity represents group of node affinity scheduling
+// rules that will be applied on NFS Server instance. If it is
+// not configured then matches to no object i.e NFS Server can
+// schedule on any node in a cluster. Configured values will be
+// propogated to deployment.spec.template.spec.affinity.nodeAffinity.
+//					requiredDuringSchedulingIgnoredDuringExecution
+//
+// Values are propagated via ENV(NodeAffinity) on NFS Provisioner.
+// Example: Following can be various options to specify NodeAffinity rules
+//
+//		Config 1: Configure across zones and also storage should be available
+//			Env Value: "kubernetes.io/hostName:[z1-host1,z2-host1,z3-host1],kubernetes.io/storage:[available]"
+//
+//  		Config 1 will be propogated as shown below on NFS-Server deployment
+//  			nodeSelectorTerms:
+//  			- matchExpressions:
+//  			  - key: kubernetes.io/hostName
+//  				operator: "In"
+//  			    values:
+//  			    - z1-host1
+//  				- z2-host2
+//  				- z3-host3
+//  			  - key: kubernetes.io/storage
+//  			    operator: "In"
+//  				values:
+//  				- available
+//
+//      Config2: Configure on storage nodes in zone1
+//			Env Value: "kubernetes.io/storage:[],kubernetes.io/zone:[zone1]"
+//
+//  		Config2 will be propogated as shown below on NFS-Server deployment
+//  			nodeSelectorTerms:
+//  			- matchExpressions:
+//  			  - key: kubernetes.io/storage
+//  			    operator: "Exists"
+//  			  - key: kubernetes.io/zone
+//  				operator: "In"
+//  			    values:
+//  			    - zone1
+//
+//
+//		Configi3: Configure on any storage node
+//			Env Value: "kubernetes.io/storage:[]"
+//
+//  		Config3 will be propogated as below on NFS-Server deployment
+//  			nodeSelectorTerms:
+//  			- matchExpressions:
+//  			  - key: kubernetes.io/storage
+//  			    operator: "Exists"
+//
+//      Like shown above various combinations can be specified and before
+//		provisioning configuration will be validated
+//
+// NOTE: All the comma separated specification will be ANDed
+type NodeAffinity struct {
+	// A list of node selector requirements by node's labels
+	MatchExpressions []corev1.NodeSelectorRequirement
+}

--- a/tests/node_affinity_test.go
+++ b/tests/node_affinity_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	pvc "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/persistentvolumeclaim"
+	provisioner "github.com/openebs/dynamic-nfs-provisioner/provisioner"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -79,7 +80,7 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 							Spec.
 							Containers[index].Env,
 						corev1.EnvVar{
-							Name:  "NODEAFFINITY",
+							Name:  provisioner.NODEAFFINITYKEY,
 							Value: nodeAffinityAsValue,
 						},
 					)
@@ -170,19 +171,14 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 			nfsProvisionerDeployment := deploymentList.Items[0]
 			for cIndex, containerDetails := range nfsProvisionerDeployment.Spec.Template.Spec.Containers {
 				if containerDetails.Name == nfsProvisionerContainerName {
-					envVars := make([]corev1.EnvVar, len(containerDetails.Env)-1)
 					envIndex := 0
 					for _, envVar := range containerDetails.Env {
-						if envVar.Name == "NODEAFFINITY" {
-							continue
+						if envVar.Name == provisioner.NODEAFFINITYKEY {
+							break
 						}
-						envVars[envIndex] = envVar
 						envIndex++
 					}
-					nfsProvisionerDeployment.Spec.
-						Template.
-						Spec.
-						Containers[cIndex].Env = envVars
+					nfsProvisionerDeployment.Spec.Template.Spec.Containers[cIndex].Env = append(nfsProvisionerDeployment.Spec.Template.Spec.Containers[cIndex].Env[:envIndex], nfsProvisionerDeployment.Spec.Template.Spec.Containers[cIndex].Env[envIndex+1:]...)
 					break
 				}
 			}

--- a/tests/node_affinity_test.go
+++ b/tests/node_affinity_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	pvc "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/persistentvolumeclaim"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
+	var (
+		openebsNamespace            = "openebs"
+		accessModes                 = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+		nodeAffinityKeys            = []string{"kubernetes.io/hostname"}
+		capacity                    = "2Gi"
+		nfsProvisionerLabel         = "openebs.io/component-name=openebs-nfs-provisioner"
+		nfsProvisionerContainerName = "openebs-provisioner-nfs"
+		pvcName                     = "pvc-nfs"
+		nodeAffinityKeyValues       map[string][]string
+	)
+
+	When("node affinity environment variable is added", func() {
+		It("should be applied", func() {
+			nodeList, err := Client.listNodes("")
+			Expect(err).To(BeNil(), "failed to list nodes")
+			var nodeAffinityAsValue string
+
+			nodeAffinityKeyValues = make(map[string][]string, len(nodeAffinityKeys))
+			// Form affinity rules from multiple nodes
+			for _, node := range nodeList.Items {
+				for _, key := range nodeAffinityKeys {
+					if value, isExist := node.Labels[key]; isExist {
+						nodeAffinityKeyValues[key] = append(nodeAffinityKeyValues[key], value)
+					}
+				}
+			}
+
+			for key, values := range nodeAffinityKeyValues {
+				nodeAffinityAsValue += key + ":["
+				for _, value := range values {
+					nodeAffinityAsValue += value + ","
+				}
+				// remove extra comma
+				nodeAffinityAsValue = nodeAffinityAsValue[:len(nodeAffinityAsValue)-1]
+				nodeAffinityAsValue += "],"
+			}
+			// remove extra comma and add key as affinity rules
+			nodeAffinityAsValue = nodeAffinityAsValue[:len(nodeAffinityAsValue)-1] + ",kubernetes.io/arch"
+			nodeAffinityKeyValues["kubernetes.io/arch"] = []string{}
+
+			deploymentList, err := Client.listDeployments(openebsNamespace, nfsProvisionerLabel)
+			Expect(err).To(BeNil(), "failed to list NFS Provisioner deployments")
+
+			nfsProvisionerDeployment := deploymentList.Items[0]
+			for index, containerDetails := range nfsProvisionerDeployment.Spec.Template.Spec.Containers {
+				if containerDetails.Name == nfsProvisionerContainerName {
+					nfsProvisionerDeployment.Spec.
+						Template.
+						Spec.
+						Containers[index].Env = append(
+						nfsProvisionerDeployment.Spec.
+							Template.
+							Spec.
+							Containers[index].Env,
+						corev1.EnvVar{
+							Name:  "NODEAFFINITY",
+							Value: nodeAffinityAsValue,
+						},
+					)
+					break
+				}
+			}
+
+			err = Client.applyDeployment(&nfsProvisionerDeployment)
+			Expect(err).To(BeNil(), "failed to add NODEAFFINITY env to NFS Provisioner")
+		})
+	})
+
+	When("pvc with storageclass openebs-rwx is created", func() {
+		It("should create NFS Server with affinity rules", func() {
+			var (
+				scName = "openebs-rwx"
+			)
+
+			By("building a pvc")
+			pvcObj, err := pvc.NewBuilder().
+				WithName(pvcName).
+				WithNamespace(applicationNamespace).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).ShouldNot(
+				HaveOccurred(),
+				"while building pvc {%s} in namespace {%s}",
+				pvcName,
+				applicationNamespace,
+			)
+
+			By("creating above pvc")
+			err = Client.createPVC(pvcObj)
+			Expect(err).To(
+				BeNil(),
+				"while creating pvc {%s} in namespace {%s}",
+				pvcName,
+				applicationNamespace,
+			)
+
+			_, err = Client.waitForPVCBound(pvcObj.Name, pvcObj.Namespace)
+			Expect(err).To(BeNil(), "While waiting for PVC to get into bound state")
+
+			boundedPVCObj, err := Client.getPVC(pvcObj.Namespace, pvcObj.Name)
+			Expect(err).To(BeNil(), "While fetching bounded PVC")
+
+			nfsServerLabel := "openebs.io/nfs-server=nfs-" + boundedPVCObj.Spec.VolumeName
+			err = Client.waitForPods(openebsNamespace, nfsServerLabel, corev1.PodRunning, 1)
+			Expect(err).To(BeNil(), "while verifying pod count")
+
+			// Get NFS Server deployment
+			nfsServerDeployment, err := Client.getDeployment(openebsNamespace, "nfs-"+boundedPVCObj.Spec.VolumeName)
+			Expect(err).To(BeNil(), "failed to list NFS Provisioner deployments")
+
+			// Verify propogation of affinity rules
+			for _, rules := range nfsServerDeployment.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+				for _, affinityRule := range rules.MatchExpressions {
+					values, isExist := nodeAffinityKeyValues[affinityRule.Key]
+					Expect(isExist).Should(BeTrue(), "unknown key %s added under node affinity rules", affinityRule.Key)
+					if len(values) == 0 {
+						Expect(affinityRule.Operator).Should(
+							Equal(corev1.NodeSelectorOpExists),
+							"operator for key %s should be %s",
+							affinityRule.Key,
+							corev1.NodeSelectorOpExists,
+						)
+						Expect(affinityRule.Values).Should(BeNil(), "values should not exist")
+					} else {
+						Expect(affinityRule.Operator).Should(
+							Equal(corev1.NodeSelectorOpIn),
+							"operator for key %s should be %s",
+							affinityRule.Key,
+							corev1.NodeSelectorOpIn,
+						)
+						Expect(affinityRule.Values).Should(Equal(values), "values should match with affinity rules")
+					}
+				}
+			}
+		})
+	})
+
+	When("node affinty rules are removed from env", func() {
+		It("should remove from the NFS provisioner", func() {
+			deploymentList, err := Client.listDeployments(openebsNamespace, nfsProvisionerLabel)
+			Expect(err).To(BeNil(), "failed to list NFS Provisioner deployments")
+
+			nfsProvisionerDeployment := deploymentList.Items[0]
+			for cIndex, containerDetails := range nfsProvisionerDeployment.Spec.Template.Spec.Containers {
+				if containerDetails.Name == nfsProvisionerContainerName {
+					envVars := make([]corev1.EnvVar, len(containerDetails.Env)-1)
+					envIndex := 0
+					for _, envVar := range containerDetails.Env {
+						if envVar.Name == "NODEAFFINITY" {
+							continue
+						}
+						envVars[envIndex] = envVar
+						envIndex++
+					}
+					nfsProvisionerDeployment.Spec.
+						Template.
+						Spec.
+						Containers[cIndex].Env = envVars
+					break
+				}
+			}
+
+			err = Client.applyDeployment(&nfsProvisionerDeployment)
+			Expect(err).To(BeNil(), "failed to add NODEAFFINITY env to NFS Provisioner")
+		})
+	})
+
+	When("pvc with storageclass openebs-rwx is deleted ", func() {
+		It("should delete the pvc", func() {
+
+			By("deleting above pvc")
+			err = Client.deletePVC(applicationNamespace, pvcName)
+			Expect(err).To(
+				BeNil(),
+				"while deleting pvc {%s} in namespace {%s}",
+				pvcName,
+				applicationNamespace,
+			)
+
+		})
+	})
+})

--- a/tests/node_affinity_test.go
+++ b/tests/node_affinity_test.go
@@ -31,7 +31,7 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 		capacity                    = "2Gi"
 		nfsProvisionerLabel         = "openebs.io/component-name=openebs-nfs-provisioner"
 		nfsProvisionerContainerName = "openebs-provisioner-nfs"
-		pvcName                     = "pvc-nfs"
+		pvcName                     = "node-affinity-pvc-nfs"
 		nodeAffinityKeyValues       map[string][]string
 	)
 

--- a/tests/node_affinity_test.go
+++ b/tests/node_affinity_test.go
@@ -80,7 +80,7 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 							Spec.
 							Containers[index].Env,
 						corev1.EnvVar{
-							Name:  provisioner.NODEAFFINITYKEY,
+							Name:  string(provisioner.NodeAffinityKey),
 							Value: nodeAffinityAsValue,
 						},
 					)
@@ -89,7 +89,7 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 			}
 
 			err = Client.applyDeployment(&nfsProvisionerDeployment)
-			Expect(err).To(BeNil(), "failed to add NODEAFFINITY env to NFS Provisioner")
+			Expect(err).To(BeNil(), "failed to add %s env to NFS Provisioner", provisioner.NodeAffinityKey)
 		})
 	})
 
@@ -136,6 +136,25 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 			nfsServerDeployment, err := Client.getDeployment(openebsNamespace, "nfs-"+boundedPVCObj.Spec.VolumeName)
 			Expect(err).To(BeNil(), "failed to list NFS Provisioner deployments")
 
+			Expect(nfsServerDeployment.Spec.Template.Spec.Affinity).NotTo(
+				BeNil(),
+				"affinity should exist on %s/%s NFS Server deployment",
+				nfsServerDeployment.Namespace,
+				nfsServerDeployment.Name,
+			)
+			Expect(nfsServerDeployment.Spec.Template.Spec.Affinity.NodeAffinity).NotTo(
+				BeNil(),
+				"node affinity should exist on %s/%s NFS Server deployment",
+				nfsServerDeployment.Namespace,
+				nfsServerDeployment.Name,
+			)
+			Expect(nfsServerDeployment.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).NotTo(
+				BeNil(),
+				"requiredDuringSchedulingIgnoreDuringExecution should exist on %s/%s NFS Server deployment",
+				nfsServerDeployment.Namespace,
+				nfsServerDeployment.Name,
+			)
+
 			// Verify propogation of affinity rules
 			for _, rules := range nfsServerDeployment.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
 				for _, affinityRule := range rules.MatchExpressions {
@@ -173,7 +192,7 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 				if containerDetails.Name == nfsProvisionerContainerName {
 					envIndex := 0
 					for _, envVar := range containerDetails.Env {
-						if envVar.Name == provisioner.NODEAFFINITYKEY {
+						if envVar.Name == string(provisioner.NodeAffinityKey) {
 							break
 						}
 						envIndex++
@@ -184,7 +203,7 @@ var _ = Describe("TEST NODE AFFINITY FEATURE", func() {
 			}
 
 			err = Client.applyDeployment(&nfsProvisionerDeployment)
-			Expect(err).To(BeNil(), "failed to add NODEAFFINITY env to NFS Provisioner")
+			Expect(err).To(BeNil(), "failed to add %s env to NFS Provisioner", provisioner.NodeAffinityKey)
 		})
 	})
 


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:
This PR adds support to specify node affinity rules via NFS-Provisioner
ENV to schedule NFS Server on a specific set of nodes. It fixes #57 

**What this PR does?**:
This PR adds a feature to propagate node affinity rules to NFS Server
instance via Provisioner ENV.

**Does this PR require any upgrade changes?**:
No

**How to use?**:
- Add 'OPENEBS_IO_NFS_SERVER_NODE_AFFINITY' ENV in NFS-Provisioner deployment in following manner:
  ```sh
  - name: OPENEBS_IO_NFS_SERVER_NODE_AFFINITY
    value: "kubernetes.io/hostname:[172.17.0.1],kubernetes.io/os:[linux]"
  ```
- To schedule NFS Server instance on storage & nfs nodes
  ```sh
  - name: OPENEBS_IO_NFS_SERVER_NODE_AFFINITY
    value: "kubernetes.io/storage,kubernetes.io/nfs-node"
  ```
  Ex: Propagation to NFS Server deployment
   ```yaml
   ...
   ...
   ...
          nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/storage-node
                operator: Exists
              - key: kubernetes.io/arch
                operator: Exists
   ```

**How it is propagated to NFS Server instance**:
- During boot-up time of provisioner instance, provisioner will read
  OPENEBS_IO_NFS_SERVER_NODE_AFFINITY ENV then parse 
  affinity rules and store them under the affinity rules in form of Go structure[in-memory].
- When volume is provisioned NFS-Provisioner will propagate this affinity
  rules to NFS Server instance.
Example propagation:
```yaml
...
...
...
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/hostname
                operator: In
                values:
                - 172.17.0.1
              - key: kubernetes.io/os
                operator: In
                values:
                - linux
```

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_

**Checklist:**
- [x] Fixes #57 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
