### PR TITLE
test(sanity): verify deletion of NFS services after deleting NFS PVC

### DIFF
--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -315,6 +315,11 @@ func (k *KubeClient) deleteStorageClass(scName string) error {
 	return k.StorageV1().StorageClasses().Delete(scName, &metav1.DeleteOptions{})
 }
 
+// Add Kubernetes service related operations
+func (k *KubeClient) getService(namespace, name string) (*corev1.Service, error) {
+	return k.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+}
+
 // Add Node related operations
 func (k *KubeClient) listNodes(labelSelector string) (*corev1.NodeList, error) {
 	return k.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: labelSelector})


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is required to verify the deletion of NFS services
after deleting NFS PVC with `Delete` reclaim policy.

**What this PR does?**:
This commit adds checks to verify deletion of NFS services(NFS service,
NFS deployment, backend PVC) after deleting NFS PVC.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>