### PR TITLE
test(reclaim policy): verify reclaim policy of NFS volumes

### DIFF
--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -230,6 +230,16 @@ func (k *KubeClient) deletePVC(namespace, pvc string) error {
 	return err
 }
 
+// Add PV related operations
+
+func (k *KubeClient) getPV(pvName string) (*corev1.PersistentVolume, error) {
+	return k.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+}
+
+func (k *KubeClient) deletePV(pvName string) error {
+	return k.CoreV1().PersistentVolumes().Delete(pvName, &metav1.DeleteOptions{})
+}
+
 func (k *KubeClient) createDeployment(deployment *appsv1.Deployment) error {
 	_, err := k.AppsV1().Deployments(deployment.Namespace).Create(deployment)
 	if err != nil {
@@ -319,6 +329,10 @@ func (k *KubeClient) deleteStorageClass(scName string) error {
 // Add Kubernetes service related operations
 func (k *KubeClient) getService(namespace, name string) (*corev1.Service, error) {
 	return k.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+}
+
+func (k *KubeClient) deleteService(namespace, name string) error {
+	return k.CoreV1().Services(namespace).Delete(name, &metav1.DeleteOptions{})
 }
 
 // Add Node related operations

--- a/tests/reclaim_policy_test.go
+++ b/tests/reclaim_policy_test.go
@@ -244,7 +244,7 @@ var _ = Describe("TEST NFS VOLUME WITH RECLAIM POLICY", func() {
 		})
 	})
 
-	When("deleting NFS service related resources", func() {
+	When("deleting NFS server resources", func() {
 		It("should get deleted", func() {
 			Expect(claimedPVCObj).NotTo(BeNil(), "claimed pvc shouldn't be nil")
 			backendNFSName := "nfs-" + claimedPVCObj.Spec.VolumeName

--- a/tests/reclaim_policy_test.go
+++ b/tests/reclaim_policy_test.go
@@ -234,6 +234,12 @@ var _ = Describe("TEST NFS VOLUME WITH RECLAIM POLICY", func() {
 			backendPVCObj, err := Client.getPVC(openebsNamespace, backendNFSName)
 			Expect(err).To(BeNil(), "while fetching backend pvc {%s} in namespace {%s}", backendNFSName, openebsNamespace)
 			Expect(backendPVCObj.DeletionTimestamp).To(BeNil(), "deletion timestamp shouldn't be set on backend pvc {%s}", backendNFSName)
+			Expect(backendPVCObj.Status.Phase).To(Equal(corev1.ClaimBound), "while verifying backed PVC claim phase")
+
+			backendPVObj, err := Client.getPV(backendPVCObj.Spec.VolumeName)
+			Expect(err).To(BeNil(), "while fetching pv {%s}", backendPVCObj.Spec.VolumeName)
+			Expect(backendPVObj.DeletionTimestamp).To(BeNil(), "deletion timestamp shouldn't be set on backend pv {%s}", backendPVObj.Name)
+			Expect(backendPVObj.Status.Phase).To(Equal(corev1.VolumeBound), "while verifying backed PV bound phase")
 
 		})
 	})

--- a/tests/reclaim_policy_test.go
+++ b/tests/reclaim_policy_test.go
@@ -1,0 +1,252 @@
+package tests
+
+import (
+	"time"
+
+	"github.com/ghodss/yaml"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	deploy "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/apps/v1/deployment"
+	container "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/container"
+	pvc "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/persistentvolumeclaim"
+	pts "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/podtemplatespec"
+	volume "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/volume"
+	provisioner "github.com/openebs/dynamic-nfs-provisioner/provisioner"
+	mayav1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+/*
+ * Following test will verify:
+ * 1. Reclaim Policy behavior of volume
+ */
+
+var _ = Describe("TEST NFS VOLUME WITH RECLAIM POLICY", func() {
+	var (
+		openebsNamespace = "openebs"
+		maxRetryCount    = 10
+
+		// SC related options
+		scNfsServerType = "kernel"
+		backendSCName   = "openebs-hostpath"
+
+		// PVC related options
+		accessModes   = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+		capacity      = "1Gi"
+		scName        = "reclaim-openebs-rwx"
+		deployName    = "busybox-reclaim-nfs"
+		pvcName       = "reclaim-nfs-pvc"
+		claimedPVCObj *corev1.PersistentVolumeClaim
+
+		// Application related options
+		label         = "demo=busybox-reclaim-nfs"
+		labelselector = map[string]string{
+			"demo": "busybox-reclaim-nfs",
+		}
+		appDeploymentBuilder = deploy.NewBuilder().
+					WithName(deployName).
+					WithNamespace(applicationNamespace).
+					WithLabelsNew(labelselector).
+					WithSelectorMatchLabelsNew(labelselector).
+					WithStrategyType(appsv1.RecreateDeploymentStrategyType).
+					WithPodTemplateSpecBuilder(
+				pts.NewBuilder().
+					WithLabelsNew(labelselector).
+					WithSecurityContext(
+						&corev1.PodSecurityContext{
+							RunAsUser: func() *int64 {
+								var val int64 = 175
+								return &val
+							}(),
+							RunAsGroup: func() *int64 {
+								var val int64 = 175
+								return &val
+							}(),
+						},
+					).
+					WithContainerBuildersNew(
+						container.NewBuilder().
+							WithName("busybox").
+							WithImage("busybox").
+							WithCommandNew(
+								[]string{
+									"/bin/sh",
+								},
+							).
+							WithArgumentsNew(
+								[]string{
+									"-c",
+									"while true ;do sleep 50; done",
+								},
+							).
+							WithVolumeMountsNew(
+								[]corev1.VolumeMount{
+									{
+										Name:      "demo-vol1",
+										MountPath: "/mnt/store1",
+									},
+								},
+							),
+					).
+					WithVolumeBuilders(
+						volume.NewBuilder().
+							WithName("demo-vol1").
+							WithPVCSource(pvcName),
+					),
+			)
+	)
+
+	When("StorageClass with reclaim policy is created", func() {
+		It("should create a StorageClass", func() {
+			reclaimPolicy := corev1.PersistentVolumeReclaimRetain
+			casObj := []mayav1alpha1.Config{
+				{
+					Name:  provisioner.KeyPVNFSServerType,
+					Value: scNfsServerType,
+				},
+				{
+					Name:  provisioner.KeyPVBackendStorageClass,
+					Value: backendSCName,
+				},
+			}
+			casObjStr, err := yaml.Marshal(casObj)
+			Expect(err).To(BeNil(), "while marshaling cas object")
+
+			err = Client.createStorageClass(&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: scName,
+					Annotations: map[string]string{
+						"openebs.io/cas-type":             "nfsrwx",
+						string(mayav1alpha1.CASConfigKey): string(casObjStr),
+					},
+				},
+				Provisioner:   "openebs.io/nfsrwx",
+				ReclaimPolicy: &reclaimPolicy,
+			})
+			Expect(err).To(BeNil(), "while creating SC {%s}", scName)
+		})
+	})
+
+	When("pvc with storageclass "+scName+" is created", func() {
+		It("should create a pvc ", func() {
+
+			By("Building PVC")
+			pvcObj, err := pvc.NewBuilder().
+				WithName(pvcName).
+				WithNamespace(applicationNamespace).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).ShouldNot(HaveOccurred(), "while building pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
+
+			By("creating PVC")
+			err = Client.createPVC(pvcObj)
+			Expect(err).To(BeNil(), "while creating pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
+		})
+	})
+
+	When("busybox deployment is created", func() {
+		It("should come into running state", func() {
+
+			By("building a deployment")
+			deployObj, err := appDeploymentBuilder.Build()
+			Expect(err).ShouldNot(HaveOccurred(), "while building deployment {%s} in namespace {%s}", deployName, applicationNamespace)
+
+			By("creating above deployment")
+			err = Client.createDeployment(deployObj)
+			Expect(err).To(BeNil(), "while creating deployment {%s} in namespace {%s}", deployName, applicationNamespace)
+
+			By("verifying pod count as 1")
+			err = Client.waitForPods(applicationNamespace, label, corev1.PodRunning, 1)
+			Expect(err).To(BeNil(), "while verifying pod count")
+		})
+	})
+
+	When("deployment is deleted", func() {
+		It("should not have any running pod", func() {
+
+			By("deleting above deployment")
+			err = Client.deleteDeployment(applicationNamespace, deployName)
+			Expect(err).To(BeNil(), "while deleting deployment {%s} in namespace {%s}", deployName, applicationNamespace)
+
+			By("verifying pod count as 0")
+			err = Client.waitForPods(applicationNamespace, label, corev1.PodRunning, 0)
+			Expect(err).To(BeNil(), "while verifying pod count")
+		})
+	})
+
+	When("pvc with storageclass reclaim-openebs-rwx is deleted ", func() {
+		It("should delete the pvc but not NFS service related artifacts", func() {
+			var err error
+
+			// Store bounded PVC object
+			claimedPVCObj, err = Client.getPVC(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while fetching pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
+
+			By("deleting pvc")
+			err = Client.deletePVC(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while deleting pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
+
+			isPVCDeleted := false
+			for retries := 0; retries < maxRetryCount; retries++ {
+				_, err := Client.getPVC(applicationNamespace, pvcName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					isPVCDeleted = true
+					break
+				}
+				time.Sleep(time.Second * 5)
+			}
+			Expect(isPVCDeleted).To(BeTrue(), "pvc should be deleted from cluster")
+
+			pvObj, err := Client.getPV(claimedPVCObj.Spec.VolumeName)
+			Expect(err).To(BeNil(), "while fetching pv {%s} details", claimedPVCObj.Spec.VolumeName)
+			Expect(pvObj.DeletionTimestamp).To(BeNil(), "deletion timestamp shouldn't be set on pv {%s}", claimedPVCObj.Spec.VolumeName)
+
+			backendNFSName := "nfs-" + claimedPVCObj.Spec.VolumeName
+			deploymentObj, err := Client.getDeployment(openebsNamespace, backendNFSName)
+			Expect(err).To(BeNil(), "while fetching deployment {%s} in namespace {%s}", backendNFSName, openebsNamespace)
+			Expect(deploymentObj.DeletionTimestamp).To(BeNil(), "deletion timestamp shouldn't be set on deployment {%s}", backendNFSName)
+
+			svcObj, err := Client.getService(openebsNamespace, backendNFSName)
+			Expect(err).To(BeNil(), "while fetching service {%s} in namespace {%s}", backendNFSName, openebsNamespace)
+			Expect(svcObj.DeletionTimestamp).To(BeNil(), "deletion timestamp shouldn't be set on service {%s}", backendNFSName)
+
+			backendPVCObj, err := Client.getPVC(openebsNamespace, backendNFSName)
+			Expect(err).To(BeNil(), "while fetching backend pvc {%s} in namespace {%s}", backendNFSName, openebsNamespace)
+			Expect(backendPVCObj.DeletionTimestamp).To(BeNil(), "deletion timestamp shouldn't be set on backend pvc {%s}", backendNFSName)
+
+		})
+	})
+
+	When("deleting NFS service related resources", func() {
+		It("should get deleted", func() {
+			Expect(claimedPVCObj).NotTo(BeNil(), "claimed pvc shouldn't be nil")
+			backendNFSName := "nfs-" + claimedPVCObj.Spec.VolumeName
+
+			err := Client.deleteService(openebsNamespace, backendNFSName)
+			Expect(err).To(BeNil(), "while deleting service {%s} in namespace {%s}", backendNFSName, openebsNamespace)
+
+			err = Client.deleteDeployment(openebsNamespace, backendNFSName)
+			Expect(err).To(BeNil(), "while deleting deployment {%s} in namespace {%s}", backendNFSName, openebsNamespace)
+
+			err = Client.deletePVC(openebsNamespace, backendNFSName)
+			Expect(err).To(BeNil(), "while deleting pvc {%s} in namespace {%s}", backendNFSName, openebsNamespace)
+
+			err = Client.deletePV(claimedPVCObj.Spec.VolumeName)
+			Expect(err).To(BeNil(), "while deleting pv {%s}", claimedPVCObj.Spec.VolumeName)
+		})
+	})
+
+	When("reclaim-openebs-rwx StorageClass is deleted ", func() {
+		It("should delete the SC", func() {
+
+			By("deleting SC")
+			err = Client.deleteStorageClass(scName)
+			Expect(err).To(BeNil(), "while deleting sc {%s}", scName)
+		})
+	})
+})

--- a/tests/reclaim_policy_test.go
+++ b/tests/reclaim_policy_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tests
 
 import (


### PR DESCRIPTION
## Pull Request template

**Why is this PR required?**:
This PR is required to verify reclaim policy support of NFS volumes.


**What this PR does?**:
This PR adds an integration test case to verify the reclaim policy
of NFS volume. Verified expected behavior:
- Deletion of application & NFS PVC should not delete NFS services
   artifacts and NFS PV.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
NA

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>