### PR TITLE
feat(volume-event): marking nfs-resources to send volume provisioning events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ license-check:
 .PHONY: sanity-test
 sanity-test: sanity-test
 	@echo "--> Running sanity test";
-	go test -v -timeout 30m ./tests/...
+	ginkgo -v ./tests/...
 
 .PHONY: push
 push:

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ ifeq (${DBUILD_SITE_URL}, )
   export DBUILD_SITE_URL
 endif
 
+# Tools required for different make
+# targets or for development purposes
+EXTERNAL_TOOLS=\
+        github.com/onsi/ginkgo/ginkgo
+
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${TAG}
 
 # include the buildx recipes
@@ -105,6 +110,15 @@ include Makefile.buildx.mk
 
 .PHONY: all
 all: test provisioner-nfs-image
+
+# Bootstrap downloads tools required
+# during build
+.PHONY: bootstrap
+bootstrap:
+	@for tool in  $(EXTERNAL_TOOLS) ; do \
+		echo "+ Installing $$tool" ; \
+		cd && GO111MODULE=on go get $$tool; \
+	done
 
 .PHONY: deps
 deps:
@@ -193,7 +207,7 @@ license-check:
 	@echo
 
 .PHONY: sanity-test
-sanity-test: sanity-test
+sanity-test: bootstrap
 	@echo "--> Running sanity test";
 	ginkgo -v ./tests/...
 

--- a/Makefile
+++ b/Makefile
@@ -111,15 +111,6 @@ include Makefile.buildx.mk
 .PHONY: all
 all: test provisioner-nfs-image
 
-# Bootstrap downloads tools required
-# during build
-.PHONY: bootstrap
-bootstrap:
-	@for tool in  $(EXTERNAL_TOOLS) ; do \
-		echo "+ Installing $$tool" ; \
-		cd && GO111MODULE=on go get $$tool; \
-	done
-
 .PHONY: deps
 deps:
 	@echo "--> Tidying up submodules"
@@ -207,9 +198,9 @@ license-check:
 	@echo
 
 .PHONY: sanity-test
-sanity-test: bootstrap
+sanity-test:
 	@echo "--> Running sanity test";
-	ginkgo -v ./tests/...
+	go test -v -timeout 40m ./tests/...
 
 .PHONY: push
 push:

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for OpenEBS Dynamic NFS PV. For instructions to install 
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.0
+version: 0.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.5.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -129,7 +129,6 @@ helm install openebs-nfs openebs-nfs/nfs-provisioner --namespace openebs --creat
 | `nfsProvisioner.tolerations`          | NFS Provisioner pod toleration values         | `""`                            |
 | `nfsProvisioner.nfsServerNamespace`          | NFS server namespace         | `"openebs"`                            |
 | `nfsProvisioner.nfsServerNodeAffinity`       | NFS Server node affinity rules                | `""`                          |
-| `nfsProvisioner.markResourcesForVolumeEvents`       | Enable NFS PV marking to send volume provisioning events                | `"false"`                          |
 | `nfsProvisioner.nfsBackendPvcTimeout`       | Timeout for backend PVC binding in seconds                | `"60"`                          |
 | `nfsStorageClass.backendStorageClass` | StorageClass to be used to provision the backend volume. If not specified, the default StorageClass is used. | `""`                         |
 | `nfsStorageClass.isDefaultClass`      | Make 'openebs-kernel-nfs' the default StorageClass | `"false"`                         |

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -129,6 +129,8 @@ helm install openebs-nfs openebs-nfs/nfs-provisioner --namespace openebs --creat
 | `nfsProvisioner.tolerations`          | NFS Provisioner pod toleration values         | `""`                            |
 | `nfsProvisioner.nfsServerNamespace`          | NFS server namespace         | `"openebs"`                            |
 | `nfsProvisioner.nfsServerNodeAffinity`       | NFS Server node affinity rules                | `""`                          |
+| `nfsProvisioner.markResourcesForVolumeEvents`       | Enable NFS PV marking to send volume provisioning events                | `"false"`                          |
+| `nfsProvisioner.nfsBackendPvcTimeout`       | Timeout for backend PVC binding in seconds                | `"60"`                          |
 | `nfsStorageClass.backendStorageClass` | StorageClass to be used to provision the backend volume. If not specified, the default StorageClass is used. | `""`                         |
 | `nfsStorageClass.isDefaultClass`      | Make 'openebs-kernel-nfs' the default StorageClass | `"false"`                         |
 | `nfsStorageClass.reclaimPolicy`       | ReclaimPolicy for NFS PVs                      | `"Delete"`                     |

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -99,6 +99,14 @@ spec:
             - name: OPENEBS_IO_NFS_SERVER_NODE_AFFINITY
               value: "{{ .Values.nfsProvisioner.nfsServerNodeAffinity }}"
             {{- end }}
+            {{- if .Values.nfsProvisioner.markResourcesForVolumeEvents }}
+            - name: OPENEBS_IO_NFS_SERVER_VOLUME_EVENTS
+              value: "{{ .Values.nfsProvisioner.markResourcesForVolumeEvents }}"
+            {{- end }}
+            {{- if .Values.nfsProvisioner.nfsBackendPvcTimeout }}
+            - name: OPENEBS_IO_NFS_SERVER_BACKEND_PVC_TIMEOUT
+              value: "{{ .Values.nfsProvisioner.nfsBackendPvcTimeout }}"
+            {{- end }}
           # Process name used for matching is limited to the 15 characters
           # present in the pgrep output.
           # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -99,10 +99,6 @@ spec:
             - name: OPENEBS_IO_NFS_SERVER_NODE_AFFINITY
               value: "{{ .Values.nfsProvisioner.nfsServerNodeAffinity }}"
             {{- end }}
-            {{- if .Values.nfsProvisioner.markResourcesForVolumeEvents }}
-            - name: OPENEBS_IO_NFS_SERVER_VOLUME_EVENTS
-              value: "{{ .Values.nfsProvisioner.markResourcesForVolumeEvents }}"
-            {{- end }}
             {{- if .Values.nfsProvisioner.nfsBackendPvcTimeout }}
             - name: OPENEBS_IO_NFS_SERVER_BACKEND_PVC_TIMEOUT
               value: "{{ .Values.nfsProvisioner.nfsBackendPvcTimeout }}"

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -143,6 +143,12 @@ spec:
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
         #  value: "true"
+        # Enable volume-event marking for nfs PV, Default is "false"
+        #- name: OPENEBS_IO_NFS_SERVER_VOLUME_EVENTS
+        #  value: "true"
+        # Set Timeout for backend PVC to bound, Default value is 60 seconds
+        #- name: OPENEBS_IO_NFS_SERVER_BACKEND_PVC_TIMEOUT
+        #  value: "60"
         # Process name used for matching is limited to the 15 characters
         # present in the pgrep output.
         # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -143,9 +143,6 @@ spec:
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
         #  value: "true"
-        # Enable volume-event marking for nfs PV, Default is "false"
-        #- name: OPENEBS_IO_NFS_SERVER_VOLUME_EVENTS
-        #  value: "true"
         # Set Timeout for backend PVC to bound, Default value is 60 seconds
         #- name: OPENEBS_IO_NFS_SERVER_BACKEND_PVC_TIMEOUT
         #  value: "60"

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v11.0.0+incompatible

--- a/provisioner/config.go
+++ b/provisioner/config.go
@@ -58,6 +58,18 @@ const (
 
 	// FSGroupID defines the permissions of nfs share volume
 	FSGroupID = "FSGID"
+
+	// Finalizer/Annotations to report volume provisioning events
+	// OpenebsEventAnnotation defines annotation to send event for k8s resources
+	OpenebsEventAnnotation = "events.openebs.io/required"
+
+	// OpenebsEventFinalizer defines finalizer for k8s resources to send
+	// event. This finalizer will be removed by the event reporter
+	OpenebsEventFinalizer = "events.openebs.io/finalizer"
+
+	// OpenebsEventFinalizerPrefix defines prefix to be added for NFS PV
+	// for OpenebsEventFinalizer
+	OpenebsEventFinalizerPrefix = "nfs."
 )
 
 const (

--- a/provisioner/env.go
+++ b/provisioner/env.go
@@ -20,7 +20,7 @@ import (
 	menv "github.com/openebs/maya/pkg/env/v1alpha1"
 )
 
-//This file defines the environement variable names that are specific
+//This file defines the environment variable names that are specific
 // to this provisioner. In addition to the variables defined in this file,
 // provisioner also uses the following:
 //   OPENEBS_NAMESPACE
@@ -54,6 +54,13 @@ const (
 
 	// NodeAffinityKey holds the env name representing Node affinity rules
 	NodeAffinityKey menv.ENVKey = "OPENEBS_IO_NFS_SERVER_NODE_AFFINITY"
+
+	// NFSVolumeEventsKey defines env name to store information about
+	// setting event finalizer and annotation on resources
+	NFSVolumeEventsKey menv.ENVKey = "OPENEBS_IO_NFS_SERVER_VOLUME_EVENTS"
+
+	// NFSBackendPvcTimeout defines env name to store BackendPvcBoundTimeout value
+	NFSBackendPvcTimeout menv.ENVKey = "OPENEBS_IO_NFS_SERVER_BACKEND_PVC_TIMEOUT"
 )
 
 var (
@@ -93,4 +100,12 @@ func getNFSServerImage() string {
 
 func getNfsServerNodeAffinity() string {
 	return menv.Get(NodeAffinityKey)
+}
+
+func getNfsVolumeEvents() string {
+	return menv.GetOrDefault(NFSVolumeEventsKey, "false")
+}
+
+func getBackendPvcTimeout() string {
+	return menv.Get(NFSBackendPvcTimeout)
 }

--- a/provisioner/helper_kernel_nfs_server.go
+++ b/provisioner/helper_kernel_nfs_server.go
@@ -602,7 +602,7 @@ func markBackendPv(client kubernetes.Interface, namespace, name string) error {
 
 	_, err = client.CoreV1().PersistentVolumes().Update(pvObj)
 	if err != nil {
-		return errors.Errorf("failed to update PV=%s", pvObj.Name)
+		return errors.Wrapf(err, "failed to update PV=%s", pvObj.Name)
 	}
 
 	return nil

--- a/provisioner/helper_kernel_nfs_server_test.go
+++ b/provisioner/helper_kernel_nfs_server_test.go
@@ -757,6 +757,7 @@ func TestGetNFSServerAddress(t *testing.T) {
 				}
 			}
 		})
+		close(stopCh)
 	}
 	os.Unsetenv(string(NFSServerImageKey))
 }

--- a/provisioner/types.go
+++ b/provisioner/types.go
@@ -18,6 +18,8 @@ limitations under the License.
 package provisioner
 
 import (
+	"time"
+
 	mconfig "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -54,6 +56,13 @@ type Provisioner struct {
 
 	// nodeAffinity specifies requirements for scheduling NFS Server
 	nodeAffinity NodeAffinity
+
+	// markResourceForVolumeEvents to set required annotation/finalizer
+	// on NFS resources to send events
+	markResourceForVolumeEvents bool
+
+	// backendPvcTimeout defines timeout for backend PVC Bound check
+	backendPvcTimeout time.Duration
 }
 
 //VolumeConfig struct contains the merged configuration of the PVC

--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -236,6 +236,10 @@ func (k *KubeClient) getPVC(pvcNamespace, pvcName string) (*corev1.PersistentVol
 	return k.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(pvcName, metav1.GetOptions{})
 }
 
+func (k *KubeClient) updatePVC(pvcObj *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	return k.CoreV1().PersistentVolumeClaims(pvcObj.Namespace).Update(pvcObj)
+}
+
 func (k *KubeClient) deletePVC(namespace, pvc string) error {
 	err := k.CoreV1().PersistentVolumeClaims(namespace).Delete(pvc, &metav1.DeleteOptions{})
 	if err != nil {

--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -259,6 +259,18 @@ func (k *KubeClient) updatePV(pvObj *corev1.PersistentVolume) (*corev1.Persisten
 	return k.CoreV1().PersistentVolumes().Update(pvObj)
 }
 
+// patchPv will create the patch from the given object and update it
+func (k *KubeClient) patchPV(oldPvObj, newPvObj *corev1.PersistentVolume) error {
+	data, _, err := getPatchData(oldPvObj, newPvObj)
+	if err != nil {
+		return err
+	}
+
+	// Patch the PV
+	_, err = k.CoreV1().PersistentVolumes().Patch(oldPvObj.Name, types.StrategicMergePatchType, data)
+	return err
+}
+
 func (k *KubeClient) deletePV(pvName string) error {
 	return k.CoreV1().PersistentVolumes().Delete(pvName, &metav1.DeleteOptions{})
 }

--- a/tests/nfs_backend_sc_retain_test.go
+++ b/tests/nfs_backend_sc_retain_test.go
@@ -158,7 +158,7 @@ var _ = Describe("TEST BACKEND PV EXISTENCE WITH BACKEND SC HAVING RETAIN POLICY
 			err := Client.deletePVC(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while deleting pvc %s/%s", applicationNamespace, pvcName)
 
-			maxRetryCount := 10
+			maxRetryCount := 20
 			isPvcDeleted := false
 			for retries := 0; retries < maxRetryCount; retries++ {
 				_, err := Client.getPVC(applicationNamespace, pvcName)
@@ -171,15 +171,16 @@ var _ = Describe("TEST BACKEND PV EXISTENCE WITH BACKEND SC HAVING RETAIN POLICY
 			Expect(isPvcDeleted).To(BeTrue(), "pvc should be deleted")
 
 			isBackendPvcDeleted := false
+			var backendPvcObj *corev1.PersistentVolumeClaim
 			for retries := 0; retries < maxRetryCount; retries++ {
-				_, err := Client.getPVC(openebsNamespace, backendPvcName)
+				backendPvcObj, err = Client.getPVC(openebsNamespace, backendPvcName)
 				if err != nil && k8serrors.IsNotFound(err) {
 					isBackendPvcDeleted = true
 					break
 				}
 				time.Sleep(time.Second * 5)
 			}
-			Expect(isBackendPvcDeleted).To(BeTrue(), "backend pvc should be deleted")
+			Expect(isBackendPvcDeleted).To(BeTrue(), fmt.Sprintf("backend pvc should be deleted, recieved PVC object=%+v", backendPvcObj))
 		})
 	})
 

--- a/tests/nfs_mark_volume_events_test.go
+++ b/tests/nfs_mark_volume_events_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pvc "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/api/core/v1/persistentvolumeclaim"
+	provisioner "github.com/openebs/dynamic-nfs-provisioner/provisioner"
+)
+
+var _ = Describe("TEST VOLUME EVENT MARKING", func() {
+	var (
+		applicationNamespace = "default"
+
+		// pvc values
+		accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+		capacity    = "2Gi"
+		pvcName     = "send-volume-event"
+
+		// nfs provisioner values
+		NFSProvisionerName = "openebs-nfs-provisioner"
+		openebsNamespace   = "openebs"
+		nfsPvName          = ""
+		backendPvcName     = ""
+		backendPvName      = ""
+	)
+
+	When("provisioner deployment updated with VolumeEvent Env", func() {
+		It("should update the provisioner deployment", func() {
+			By("waiting for deployment rollout")
+			err = Client.waitForDeploymentRollout(OpenEBSNamespace, NFSProvisionerName)
+			Expect(err).To(BeNil(), "while verifying deployment rollout")
+
+			By("updating a deployment")
+			deploy, err := Client.getDeployment(OpenEBSNamespace, NFSProvisionerName)
+			Expect(err).To(
+				BeNil(),
+				"while fetching deployment {%s} in namespace {%s}",
+				NFSProvisionerName,
+				OpenEBSNamespace,
+			)
+
+			By("updating the deployment")
+			nsEnv := corev1.EnvVar{
+				Name:  string(provisioner.NFSVolumeEventsKey),
+				Value: "true",
+			}
+
+			deploy.Spec.Template.Spec.Containers[0].Env = append(
+				deploy.Spec.Template.Spec.Containers[0].Env,
+				nsEnv,
+			)
+			_, err = Client.updateDeployment(deploy)
+			Expect(err).To(
+				BeNil(),
+				"while updating deployment {%s} in namespace {%s}",
+				NFSProvisionerName,
+				OpenEBSNamespace,
+			)
+			By("waiting for deployment rollout")
+			err = Client.waitForDeploymentRollout(OpenEBSNamespace, NFSProvisionerName)
+			Expect(err).To(BeNil(), "while verifying deployment rollout")
+		})
+	})
+
+	When("pvc with storageclass openebs-rwx is created", func() {
+		It("should create a pvc ", func() {
+			var (
+				scName = "openebs-rwx"
+			)
+
+			By("building a pvc")
+			pvcObj, err := pvc.NewBuilder().
+				WithName(pvcName).
+				WithNamespace(applicationNamespace).
+				WithStorageClass(scName).
+				WithAccessModes(accessModes).
+				WithCapacity(capacity).Build()
+			Expect(err).To(BeNil(), "while building pvc %s/%s object", applicationNamespace, pvcName)
+
+			By("creating above pvc")
+			err = Client.createPVC(pvcObj)
+			Expect(err).To(BeNil(), "while creating pvc %s/%s", applicationNamespace, pvcName)
+
+			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
+			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
+
+			nfsPvcObj, err := Client.getPVC(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while fetching pvc %s/%s", applicationNamespace, pvcName)
+
+			backendPvcName = "nfs-pvc-" + string(nfsPvcObj.UID)
+			nfsPvName = nfsPvcObj.Spec.VolumeName
+
+			backendPvcObj, err := Client.getPVC(openebsNamespace, backendPvcName)
+			Expect(err).To(BeNil(), "while fetching pvc %s/%s", openebsNamespace, pvcName)
+			Expect(eventFinalizerExists(&backendPvcObj.ObjectMeta)).To(BeTrue(), "volume-event finalizer should be set")
+			Expect(eventAnnotationExists(&backendPvcObj.ObjectMeta)).To(BeFalse(), "volume-event annotation should not be set")
+
+			backendPvName = backendPvcObj.Spec.VolumeName
+
+			backendPvObj, err := Client.getPV(backendPvName)
+			Expect(err).To(BeNil(), "while fetching backend PV=%s", backendPvName)
+			Expect(eventFinalizerExists(&backendPvObj.ObjectMeta)).To(BeTrue(), "volume-event finalizer should be set")
+			Expect(eventAnnotationExists(&backendPvObj.ObjectMeta)).To(BeFalse(), "volume-event annotation should be set")
+
+			nfsPvObj, err := Client.getPV(nfsPvName)
+			Expect(err).To(BeNil(), "while fetching NFS PV=%s", nfsPvName)
+			Expect(eventFinalizerExists(&nfsPvObj.ObjectMeta)).To(BeTrue(), "volume-event finalizer should be set")
+			Expect(eventAnnotationExists(&nfsPvObj.ObjectMeta)).To(BeTrue(), "volume-event annotation should be set")
+		})
+	})
+
+	When("pvc with storageclass openebs-rwx is deleted ", func() {
+		It("should not delete the pvc", func() {
+			By("deleting the pvc")
+			err := Client.deletePVC(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while deleting pvc %s/%s", applicationNamespace, pvcName)
+
+			maxRetryCount := 10
+			var nfsPvcDeleted bool
+			for retries := 0; retries < maxRetryCount; retries++ {
+				_, err := Client.getPVC(applicationNamespace, pvcName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					nfsPvcDeleted = true
+					break
+				}
+				time.Sleep(time.Second * 5)
+			}
+			Expect(nfsPvcDeleted).To(BeTrue(), "NFS pvc should be deleted")
+
+			backendPvcObj, err := Client.getPVC(openebsNamespace, backendPvcName)
+			Expect(err).To(BeNil(), "while fetching pvc %s/%s", openebsNamespace, backendPvcName)
+			Expect(backendPvcObj.DeletionTimestamp).NotTo(BeNil(), "backend PVC should be in Terminating state")
+			Expect(eventFinalizerExists(&backendPvcObj.ObjectMeta)).To(BeTrue(), "volume-event finalizer should be set")
+			Expect(eventAnnotationExists(&backendPvcObj.ObjectMeta)).To(BeFalse(), "volume-event annotation should not be set")
+
+			backendPvName = backendPvcObj.Spec.VolumeName
+
+			backendPvObj, err := Client.getPV(backendPvName)
+			Expect(err).To(BeNil(), "while fetching backend PV=%s", backendPvName)
+			Expect(backendPvObj.DeletionTimestamp).To(BeNil(), "backend PV should not be in Terminating state")
+			Expect(eventFinalizerExists(&backendPvObj.ObjectMeta)).To(BeTrue(), "volume-event finalizer should be set")
+			Expect(eventAnnotationExists(&backendPvObj.ObjectMeta)).To(BeFalse(), "volume-event annotation should not be set")
+
+			nfsPvObj, err := Client.getPV(nfsPvName)
+			Expect(err).To(BeNil(), "while fetching NFS PV=%s", nfsPvName)
+			Expect(nfsPvObj.DeletionTimestamp).NotTo(BeNil(), "NFS PV should be in Terminating state")
+			Expect(eventFinalizerExists(&nfsPvObj.ObjectMeta)).To(BeTrue(), "volume-event finalizer should be set")
+			Expect(eventAnnotationExists(&nfsPvObj.ObjectMeta)).To(BeTrue(), "volume-event annotation should be set")
+		})
+	})
+
+	When("cleaning up backend PV", func() {
+		It("should delete backend PV", func() {
+			backendPvcObj, err := Client.getPVC(openebsNamespace, backendPvcName)
+			Expect(err).To(BeNil(), "while fetching pvc %s/%s", openebsNamespace, backendPvcName)
+			removeEventFinalizer(&backendPvcObj.ObjectMeta)
+			_, err = Client.updatePVC(backendPvcObj)
+			Expect(err).To(BeNil(), "while updating pvc %s/%s", openebsNamespace, backendPvcName)
+
+			backendPvObj, err := Client.getPV(backendPvName)
+			Expect(err).To(BeNil(), "while fetching backend PV=%s", backendPvName)
+			removeEventFinalizer(&backendPvObj.ObjectMeta)
+			_, err = Client.updatePV(backendPvObj)
+			Expect(err).To(BeNil(), "while updating backend PV=%s", backendPvName)
+
+			nfsPvObj, err := Client.getPV(nfsPvName)
+			Expect(err).To(BeNil(), "while fetching NFS PV=%s", nfsPvName)
+			removeEventFinalizer(&nfsPvObj.ObjectMeta)
+			_, err = Client.updatePV(nfsPvObj)
+			Expect(err).To(BeNil(), "while updating NFS PV=%s", nfsPvName)
+
+			maxRetryCount := 10
+			var (
+				backendPvcDeleted bool
+				backendPvDeleted  bool
+				nfsPvDeleted      bool
+			)
+
+			for retries := 0; retries < maxRetryCount; retries++ {
+				_, err := Client.getPVC(openebsNamespace, backendPvcName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					backendPvcDeleted = true
+					break
+				}
+				time.Sleep(time.Second * 5)
+			}
+
+			for retries := 0; retries < maxRetryCount; retries++ {
+				_, err := Client.getPV(backendPvName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					backendPvDeleted = true
+					break
+				}
+				time.Sleep(time.Second * 5)
+			}
+
+			for retries := 0; retries < maxRetryCount; retries++ {
+				_, err := Client.getPV(nfsPvName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					nfsPvDeleted = true
+					break
+				}
+				time.Sleep(time.Second * 5)
+			}
+			Expect(backendPvcDeleted).To(BeTrue(), "backend pvc should be deleted")
+			Expect(backendPvDeleted).To(BeTrue(), "backend PV should be deleted")
+			Expect(nfsPvDeleted).To(BeTrue(), "NFS PV should be deleted")
+		})
+	})
+
+	When("VolumeEvent Env removed from provisioner", func() {
+		It("should update the provisioner deployment", func() {
+
+			By("updating a deployment")
+			deploy, err := Client.getDeployment(OpenEBSNamespace, NFSProvisionerName)
+			Expect(err).To(
+				BeNil(),
+				"while fetching deployment {%s} in namespace {%s}",
+				NFSProvisionerName,
+				OpenEBSNamespace,
+			)
+
+			By("updating the provisioner deployment")
+			idx := 0
+			for idx < len(deploy.Spec.Template.Spec.Containers[0].Env) {
+				if deploy.Spec.Template.Spec.Containers[0].Env[idx].Name == string(provisioner.NFSVolumeEventsKey) {
+					break
+				}
+				idx++
+			}
+			deploy.Spec.Template.Spec.Containers[0].Env = append(deploy.Spec.Template.Spec.Containers[0].Env[:idx], deploy.Spec.Template.Spec.Containers[0].Env[idx+1:]...)
+			_, err = Client.updateDeployment(deploy)
+			Expect(err).To(
+				BeNil(),
+				"while updating deployment {%s} in namespace {%s}",
+				NFSProvisionerName,
+				OpenEBSNamespace,
+			)
+
+			By("waiting for deployment rollout")
+			err = Client.waitForDeploymentRollout(OpenEBSNamespace, NFSProvisionerName)
+			Expect(err).To(BeNil(), "while verifying deployment rollout")
+		})
+	})
+
+})
+
+func eventFinalizerExists(objMeta *metav1.ObjectMeta) bool {
+	eventFinalizer := provisioner.OpenebsEventFinalizerPrefix + provisioner.OpenebsEventFinalizer
+
+	for _, f := range objMeta.Finalizers {
+		if f == eventFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func eventAnnotationExists(objMeta *metav1.ObjectMeta) bool {
+	for k, v := range objMeta.Annotations {
+		if k == provisioner.OpenebsEventAnnotation && v == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+func removeEventFinalizer(objMeta *metav1.ObjectMeta) {
+	eventFinalizer := provisioner.OpenebsEventFinalizerPrefix + provisioner.OpenebsEventFinalizer
+	for i, f := range objMeta.Finalizers {
+		if f == eventFinalizer {
+			objMeta.Finalizers = append(objMeta.Finalizers[:i], objMeta.Finalizers[i+1:]...)
+			break
+		}
+	}
+	return
+}

--- a/tests/provisioner_with_invalid_backend_sc.go
+++ b/tests/provisioner_with_invalid_backend_sc.go
@@ -18,7 +18,6 @@ package tests
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
@@ -42,11 +41,9 @@ var _ = Describe("TEST NFS PROVISIONER WITH INVALID BACKEND SC", func() {
 		pvcName     = "pvc-invalid-backend-sc"
 
 		// nfs provisioner values
-		openebsNamespace = "openebs"
-		nfsServerLabel   = "openebs.io/nfs-server"
-		scName           = "nfs-server-invalid-sc"
-		backendScName    = "nfs-invalid-backend-sc"
-		scNfsServerType  = "kernel"
+		scName          = "nfs-server-invalid-sc"
+		backendScName   = "nfs-invalid-backend-sc"
+		scNfsServerType = "kernel"
 	)
 
 	When("create storageclass with nfs configuration", func() {
@@ -89,48 +86,19 @@ var _ = Describe("TEST NFS PROVISIONER WITH INVALID BACKEND SC", func() {
 				WithStorageClass(scName).
 				WithAccessModes(accessModes).
 				WithCapacity(capacity).Build()
-			Expect(err).To(BeNil(), "while building pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
+			Expect(err).To(BeNil(), "while building pvc object for %s/%s", applicationNamespace, pvcName)
 
 			By("creating above pvc")
 			err = Client.createPVC(pvcObj)
-			Expect(err).To(BeNil(), "while creating pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
-
-			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
-			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while creating pvc %s/%s", applicationNamespace, pvcName)
 		})
 	})
 
-	When("verifying nfs-server state", func() {
-		It("should have nfs-server in pending state", func() {
-			By("fetching nfs-server deployment name")
+	When("verifying NFS PVC state", func() {
+		It("should have NFS PVC in pending state", func() {
 			pvcObj, err := Client.getPVC(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while fetching pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
-
-			nfsDeployment := fmt.Sprintf("nfs-%s", pvcObj.Spec.VolumeName)
-			podList, err := Client.listPods(openebsNamespace, fmt.Sprintf("%s=%s", nfsServerLabel, nfsDeployment))
-			Expect(err).To(BeNil(), "while fetching nfs-server pod")
-			Expect(podList.Items[0].Status.Phase).To(Equal(corev1.PodPending), "while verifying nfs-server pod state")
-
-			var unboundPVCCondFound bool
-			for _, v := range podList.Items[0].Status.Conditions {
-				if strings.Contains(v.Message, "pod has unbound immediate PersistentVolumeClaims") {
-					unboundPVCCondFound = true
-				}
-			}
-			Expect(unboundPVCCondFound).Should(BeTrue(), "while checking unbound PVC condition for nfs-server pod")
-		})
-	})
-
-	When("verifying backend PVC state", func() {
-		It("should have backend in pending state", func() {
-			pvcObj, err := Client.getPVC(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while fetching pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
-
-			backendPVCName := "nfs-" + pvcObj.Spec.VolumeName
-			backendPvcObj, err := Client.getPVC(openebsNamespace, backendPVCName)
-			Expect(err).To(BeNil(), "while fetching backend pvc {%s} in namespace {%s}", backendPVCName, openebsNamespace)
-			Expect(backendPvcObj.Status.Phase).To(Equal(corev1.ClaimPending), "while verifying backed PVC claim phase")
+			Expect(err).To(BeNil(), "while fetching pvc %s/%s", applicationNamespace, pvcName)
+			Expect(pvcObj.Status.Phase).To(Equal(corev1.ClaimPending), "while verifying NFS PVC claim phase")
 		})
 	})
 
@@ -138,8 +106,7 @@ var _ = Describe("TEST NFS PROVISIONER WITH INVALID BACKEND SC", func() {
 		It("should delete the pvc", func() {
 			By("deleting above pvc")
 			err := Client.deletePVC(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while deleting pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
-
+			Expect(err).To(BeNil(), "while deleting pvc %s/%s", applicationNamespace, pvcName)
 		})
 	})
 


### PR DESCRIPTION
**What this PR does?**:
This PR adds the following changes:
-  Mark NFS resources to send volume events on nfs volume provisioning. To mark the nfs resources, the provisioner adds
           -   **Annotation** `events.openebs.io/required:"true"` on NFS PV
           -   **Finalizer** `nfs.events.openebs.io/finalizer` on backend PVC, backend PV, and NFS PV resource
- Added option to configure timeout backend PVC bound phase by setting env variable OPENEBS_IO_NFS_SERVER_BACKEND_PVC_TIMEOUT in nfs provisioner deployment. If not mentioned then the default value of 60 seconds will be used for backend PVC bound timeout.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 