### PR TITLE
chore(test): disable OpenEBS analytics reports in GitHub action

### DIFF
--- a/tests/install-nfs-provisioner.sh
+++ b/tests/install-nfs-provisioner.sh
@@ -14,9 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+on_exit() {
+
+    ## Changing back to original value
+    sed -i '/OPENEBS_IO_ENABLE_ANALYTICS/!b;n;c\          value: "true"' deploy/kubectl/openebs-nfs-provisioner.yaml
+}
+
+trap 'on_exit' EXIT
+
 sed -i 's/#- name: BackendStorageClass/- name: BackendStorageClass/' deploy/kubectl/openebs-nfs-provisioner.yaml
 sed -i 's/#  value: "openebs-hostpath"/  value: "openebs-hostpath"/' deploy/kubectl/openebs-nfs-provisioner.yaml
-
+## !b negates the previous address and breaks out of any processing, end the sed commands,
+## n prints the current line and reads the next line into pattern space,
+## c changes the current line to the string following command
+sed -i '/OPENEBS_IO_ENABLE_ANALYTICS/!b;n;c\          value: "false"' deploy/kubectl/openebs-nfs-provisioner.yaml
 kubectl  apply -f deploy/kubectl/openebs-nfs-provisioner.yaml
 
 function waitForDeployment() {


### PR DESCRIPTION



**Why is this PR required? What issue does it fix?**:
Disables analytics report generation for volumes provisioning in GitHub actions.

**What this PR does?**:
This commit disables OpenEBS analytics reports in GitHub action tests

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating NFS-Provisioner Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>