### PR TITLE
chore(docs): updating links for openebs gh repos

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,6 +1,6 @@
 # OpenEBS Dynamic NFS Volume Provisioner
 
-You can see the full list of organizations/users using OpenEBS [here](https://github.com/openebs/openebs/blob/master/ADOPTERS.md).
+You can see the full list of organizations/users using OpenEBS [here](https://github.com/openebs/openebs/blob/HEAD/ADOPTERS.md).
 
 If you are using Dynamic NFS, and would like yourself to be listed in this page, please raise an [issue](https://github.com/openebs/dynamic-nfs-provisioner/issues/new?assignees=&labels=&template=become-an-adopter.md&title=%5BADOPTER%5D) with the following details:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ OpenEBS uses the standard GitHub pull requests process to review and accept cont
 * If you are a first-time contributor, please see [Steps to Contribute](#steps-to-contribute).
 * If you have documentation improvement ideas, go ahead and create a pull request. See [Pull Request checklist](#pull-request-checklist).
 * If you would like to make code contributions, please start with [Setting up the Development Environment](#setting-up-your-development-environment).
-* If you would like to work on something more involved, please connect with the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/master/community).
+* If you would like to work on something more involved, please connect with the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/HEAD/community).
 
 ## Steps to Contribute
 
@@ -14,7 +14,7 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 * Find an issue to work on or create a new issue. The issues are maintained at [openebs/openebs](https://github.com/openebs/openebs/issues). You can pick up from a list of [good-first-issues](https://github.com/openebs/openebs/labels/good%20first%20issue).
 * Claim your issue by commenting your intent to work on it to avoid duplication of efforts.
 * Fork the repository on GitHub.
-* Create a branch from where you want to base your work (usually master).
+* Create a branch from where you want to base your work (usually develop).
 * Make your changes. If you are working on code contributions, please see [Setting up the Development Environment](#setting-up-your-development-environment).
 * Relevant coding style guidelines are the [Go Code Review Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments) and the _Formatting and style_ section of Peter Bourgon's [Go: Best Practices for Production Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).
 * Commit your changes by making sure the commit messages convey the need and notes about the commit.
@@ -23,18 +23,18 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 
 ## Pull Request Checklist
 
-* Rebase to the current master branch before submitting your pull request.
+* Rebase to the current develop branch before submitting your pull request.
 * Commits should be as small as possible. Each commit should follow the checklist below:
   - For code changes, add tests relevant to the fixed bug or new feature.
   - Pass the compile and tests - includes spell checks, formatting, etc.
   - Commit header (first line) should convey what changed.
   - Commit body should include details such as why the changes are required and how the proposed changes.
   - DCO Signed.
-* If your PR is not getting reviewed or you need a specific person to review it, please reach out to the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/master/community).
+* If your PR is not getting reviewed or you need a specific person to review it, please reach out to the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/HEAD/community).
 
 ## Sign your work
 
-We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS project. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/master/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
+We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS project. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/HEAD/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
 
 ```
   Signed-off-by: Random J Developer <random@developer.example.org>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,2 +1,2 @@
 This is a OpenEBS sub project and abides by the 
-[OpenEBS Project Governance](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).
+[OpenEBS Project Governance](https://github.com/openebs/openebs/blob/HEAD/GOVERNANCE.md).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Slack](https://img.shields.io/badge/chat!!!-slack-ff1493.svg?style=flat-square)](https://kubernetes.slack.com/messages/openebs)
 [![BCH compliance](https://bettercodehub.com/edge/badge/openebs/dynamic-nfs-provisioner?branch=develop)](https://bettercodehub.com/results/openebs/dynamic-nfs-provisioner)
 
-<img width="300" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
+<img width="300" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/HEAD/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
 
 <p align="justify">
 <strong>OpenEBS Dynamic NFS PV provisioner</strong> can be used to dynamically provision 
@@ -95,7 +95,7 @@ OpenEBS welcomes your feedback and contributions in any form possible.
 
 ## Community, discussion, and support
 
-Learn how to engage with the OpenEBS community on the [community page](https://github.com/openebs/openebs/tree/master/community).
+Learn how to engage with the OpenEBS community on the [community page](https://github.com/openebs/openebs/tree/HEAD/community).
 
 You can reach the maintainers of this project at:
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
This PR updates the external repo link(i.e openebs GH repos) using reference `HEAD`.

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating NFS-Provisioner Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 