### PR TITLE
chore(analytic): send install event on nfs-provisioner start

### DIFF
--- a/provisioner/controller.go
+++ b/provisioner/controller.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/klog/v2"
 
 	mKube "github.com/openebs/dynamic-nfs-provisioner/pkg/kubernetes/client"
+	menv "github.com/openebs/maya/pkg/env/v1alpha1"
+	analytics "github.com/openebs/maya/pkg/usage"
 	pvController "sigs.k8s.io/sig-storage-lib-external-provisioner/v7/controller"
 )
 
@@ -75,6 +77,11 @@ func Start(ctx context.Context) error {
 
 	//Run the provisioner till a shutdown signal is received.
 	go pc.Run(ctx)
+
+	if menv.Truthy(menv.OpenEBSEnableAnalytics) {
+		analytics.New().Build().InstallBuilder(true).Send()
+		go analytics.PingCheck()
+	}
 
 	<-ctx.Done()
 	klog.V(4).Info("Provisioner stopped")


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
This PR enable nfs-provisioner to send *Installation* and *Ping* event

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating NFS-Provisioner Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
