### PR TITLE
chore(chart): updates nfs-provisioner version to 0.7.1

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,10 +4,10 @@ description: Helm chart for OpenEBS Dynamic NFS PV. For instructions to install 
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.1
+version: 0.7.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.6.1
+appVersion: 0.7.1
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -117,13 +117,13 @@ helm install openebs-nfs openebs-nfs/nfs-provisioner --namespace openebs --creat
 | `nfsProvisioner.healthCheck.periodSeconds` | How often to perform the liveness probe        | `60`                           | 
 | `nfsProvisioner.image.registry`       | Registry for NFS Provisioner image            | `""`                            |
 | `nfsProvisioner.image.repository`     | Image repository for NFS Provisioner          | `openebs/provisioner-nfs`       |
-| `nfsProvisioner.image.tag`            | Image tag for NFS Provisioner	                | `0.6.1`                            |
+| `nfsProvisioner.image.tag`            | Image tag for NFS Provisioner	                | `0.7.1`                            |
 | `nfsProvisioner.image.pullPolicy`     | Image pull policy for NFS Provisioner image   | `IfNotPresent`                  |
 | `nfsProvisioner.annotations`          | Annotations for NFS Provisioner metadata      | `""`                            |
 | `nfsProvisioner.nodeSelector`         | Nodeselector for NFS Provisioner pod          | `""`                            |
 | `nfsProvisioner.nfsServerAlpineImage.registry`         | Registry for nfs-server-alpine          | `""`                            |
 | `nfsProvisioner.nfsServerAlpineImage.repository`         | Image repository for nfs-server-alpine          | `openebs/nfs-server-alpine`                            |
-| `nfsProvisioner.nfsServerAlpineImage.tag`         | Image tag for nfs-server-alpine          | `0.6.1`                            |
+| `nfsProvisioner.nfsServerAlpineImage.tag`         | Image tag for nfs-server-alpine          | `0.7.1`                            |
 | `nfsProvisioner.resources`            | Resource request and limit for the container  | `true`                          |
 | `nfsProvisioner.securityContext`      | Security context for container                | `""`                            |
 | `nfsProvisioner.tolerations`          | NFS Provisioner pod toleration values         | `""`                            |

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: OPENEBS_IO_NFS_SERVER_USE_CLUSTERIP
               value: "{{ .Values.nfsServer.useClusterIP }}"
             - name: OPENEBS_IO_INSTALLER_TYPE
-              value: "charts-helm"
+              value: "nfs-helm"
             # OPENEBS_IO_NFS_SERVER_IMG defines the nfs-server-alpine image name to be used
             # while creating nfs volume
             - name: OPENEBS_IO_NFS_SERVER_IMG


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR supports to install 0.7.1 version of OpenEBS dynamic-nfs-provisioner

**What this PR does?**:
This PR does the following changes:
- Update README.md
- Update Charts version
- Update `OPENEBS_IO_INSTALLER_TYPE` value in deployment.yaml

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes, By running helm installation command

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating NFS-Provisioner Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>