### PR TITLE
feat(hook): load hook configuration using file instead of configmap

### DIFF
--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -176,6 +176,16 @@ spec:
           limits:
             cpu: 200m
             memory: 200M
+        volumeMounts:
+        # uncomment below lines to use nfs-hooks
+        #   - mountPath: /etc/nfs-provisioner
+        #     name: hook-config
+      volumes:
+        # uncomment below lines to use nfs-hooks
+        # - name: hook-config
+          # configMap:
+           #  name: hook-config
+
 ---
 #Sample storage classes for OpenEBS Local PV
 apiVersion: storage.k8s.io/v1

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -176,12 +176,12 @@ spec:
           limits:
             cpu: 200m
             memory: 200M
-        volumeMounts:
         # uncomment below lines to use nfs-hooks
+        # volumeMounts:
         #   - mountPath: /etc/nfs-provisioner
         #     name: hook-config
-      volumes:
-        # uncomment below lines to use nfs-hooks
+      # uncomment below lines to use nfs-hooks
+      # volumes:
         # - name: hook-config
           # configMap:
            #  name: hook-config

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -140,8 +140,6 @@ spec:
         - name: OPENEBS_IO_NFS_SERVER_IMG
           value: openebs/nfs-server-alpine:ci
         # OPENEBS_IO_NFS_HOOK_CONFIGMAP defines configmap to use for hook
-        #- name: OPENEBS_IO_NFS_HOOK_CONFIGMAP
-        #  value: "nfs-hook"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED

--- a/docs/design/hooks.md
+++ b/docs/design/hooks.md
@@ -62,7 +62,7 @@ NFS Provisioner will load the hook configuration from the file located at pre-de
           initialDelaySeconds: 30
           periodSeconds: 60
         volumeMounts:
-          - mountPath: /etc/nfs-provisioner-hook
+          - mountPath: /etc/nfs-provisioner
             name: hook-config
       volumes:
         - name: hook-config
@@ -199,7 +199,7 @@ type Provisioner struct {
 ```
 
 #### Configmap structure
-User needs to create hook Configmap resource in nfs-provisioner namespace. Hook configuration needs to be provided in data field **config**.
+User needs to create hook Configmap resource in nfs-provisioner namespace. Hook configuration needs to be provided in data field **hook-config**.
 Configmap needs be defined as below:
 
 ```yaml
@@ -209,7 +209,7 @@ metadata:
   name: hook-config
   namespace: openebs
 data:
-  config: |
+  hook-config: |
     hooks:
       addOrUpdateEntriesOnCreateVolumeEvent:
         backendPV:
@@ -281,7 +281,7 @@ For initial development, following template variables will be supported:
 
 
 #### NFS Provisioner changes
-NFS Provisioner will initialize the hook configuration using pre-defined hook config file(*/etc/nfs-provisioner-hook/config*). If hook config file is not found then NFS Provisioner will skip the initialization of hooks and continue with provisioning.
+NFS Provisioner will initialize the hook configuration using pre-defined hook config file(*/etc/nfs-provisioner/hook-config*). If hook config file is not found then NFS Provisioner will skip the initialization of hooks and continue with provisioning.
 
 NFS Provisioner executes two events, volume provisioning, and volume deletion. On these two events provisioner needs to execute all the hooks as per the given hook Action.
 

--- a/docs/design/hooks.md
+++ b/docs/design/hooks.md
@@ -39,10 +39,10 @@ I should be able to configure nfs-provisioner to set the provided annotation and
 I should be able to configure nfs-provisioner to set the provided annotation and finalizer on specific resources created by nfs-provisioner.
 
 ### Proposed Implementation
-NFS-Provisioner will use user-provided Configmap to learn hooks configuration. These hooks will be executed on volume provisioning or deleting events to set the given information on provided resources. 
+NFS-Provisioner will use user-provided Config file to learn hooks configuration. These hooks will be executed on volume provisioning or deleting events to set the given information on provided resources. 
 
 ### High-Level Design
-User will deploy nfs-provisioner with Configmap having information about hook information. This Configmap should exist in the same namespace in which nfs-provisioner is deployed. Sample nfs-provisioner deployment config is as below:
+NFS Provisioner will load the hook configuration from the file located at pre-defined path. User can create a configmap with hook configuration and mount it at pre-defined path. Sample nfs-provisioner deployment config is as below:
 
 ```yaml
     spec:
@@ -61,9 +61,16 @@ User will deploy nfs-provisioner with Configmap having information about hook in
             - test `pgrep "^provisioner-nfs.*"` = 1
           initialDelaySeconds: 30
           periodSeconds: 60
+        volumeMounts:
+          - mountPath: /etc/nfs-provisioner-hook
+            name: hook-config
+      volumes:
+        - name: hook-config
+          configMap:
+            name: hook-config
 ```
 
-User needs to provide Configmap name as a value of `OPENEBS_IO_NFS_HOOK_CONFIGMAP` environment variable.
+User needs to create a configmap named 'hook-config' in provisioner's namespace.
 
 ### Low-Level Design
 #### Hook Definition
@@ -274,7 +281,8 @@ For initial development, following template variables will be supported:
 
 
 #### NFS Provisioner changes
-If NFS Provisioner is configured with environment variable **OPENEBS_IO_NFS_HOOK_CONFIGMAP** set then Provisioner needs to lookup the provided Configmap in nfs-provisioner namespace. If Configmap exists then provisioner needs to initialize **Provisioner** with hook configuration provided in Configmap.
+NFS Provisioner will initialize the hook configuration using pre-defined hook config file(*/etc/nfs-provisioner-hook/config*). If hook config file is not found then NFS Provisioner will skip the initialization of hooks and continue with provisioning.
+
 NFS Provisioner executes two events, volume provisioning, and volume deletion. On these two events provisioner needs to execute all the hooks as per the given hook Action.
 
 NFS Provisioner will initialize the hook on startup. If Hook configuration is invalid then NFS Provisioner will throw the error and exit.

--- a/provisioner/config.go
+++ b/provisioner/config.go
@@ -20,6 +20,7 @@ package provisioner
 import (
 	"context"
 	"github.com/pkg/errors"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -304,7 +305,7 @@ func initializeHook(hook **nfshook.Hook) error {
 		return nil
 	}
 
-	data, err := os.ReadFile(HookConfigFilePath)
+	data, err := ioutil.ReadFile(HookConfigFilePath)
 	if err != nil {
 		return errors.Errorf("failed to read hook config file, err=%s", err)
 	}

--- a/provisioner/config.go
+++ b/provisioner/config.go
@@ -67,12 +67,14 @@ const (
 	// NFSServerResourceLimits holds key name that represent NFS Resource Limits
 	NFSServerResourceLimits = "NFSServerResourceLimits"
 
-	// Hook Configuration
-	// HookConfigDirectory defines directory for hook configuration
-	HookConfigDirectory = "/etc/nfs-provisioner-hook"
+	// HookConfigFileName represent file name for hook configuration
+	HookConfigFileName = "hook-config"
+
+	// ConfigDirectory defines directory to store config files specific to NFS provisioner
+	ConfigDirectory = "/etc/nfs-provisioner"
 
 	// HookConfigFilePath defines path for hook config file
-	HookConfigFilePath = HookConfigDirectory + "/config"
+	HookConfigFilePath = ConfigDirectory + "/" + HookConfigFileName
 )
 
 const (
@@ -310,7 +312,7 @@ func initializeHook(hook **nfshook.Hook) error {
 		return errors.Errorf("failed to read hook config file, err=%s", err)
 	}
 
-	hookObj, err := nfshook.ParseHooks([]byte(data))
+	hookObj, err := nfshook.ParseHooks(data)
 	if err != nil {
 		return err
 	}

--- a/provisioner/env.go
+++ b/provisioner/env.go
@@ -60,9 +60,6 @@ const (
 
 	// NFSServerImagePullSecret defines the env name to store the name of the image pull secret
 	NFSServerImagePullSecret menv.ENVKey = "OPENEBS_IO_NFS_SERVER_IMAGE_PULL_SECRET"
-
-	// NFSHookConfigMapName defines env variable name to hold hook configmap name
-	NFSHookConfigMapName menv.ENVKey = "OPENEBS_IO_NFS_HOOK_CONFIGMAP"
 )
 
 var (
@@ -110,8 +107,4 @@ func getBackendPvcTimeout() string {
 
 func getNfsServerImagePullSecret() string {
 	return menv.GetOrDefault(NFSServerImagePullSecret, "")
-}
-
-func getHookConfigMapName() string {
-	return menv.Get(NFSHookConfigMapName)
 }

--- a/tests/nfs_hook_test.go
+++ b/tests/nfs_hook_test.go
@@ -129,7 +129,7 @@ var _ = Describe("TEST NFS HOOK", func() {
 			cmap.Name = hookConfigMapName
 			cmap.Namespace = openebsNamespace
 			cmap.Data = map[string]string{
-				"config": string(data),
+				provisioner.HookConfigFileName: string(data),
 			}
 
 			err = Client.createConfigMap(&cmap)
@@ -171,7 +171,7 @@ var _ = Describe("TEST NFS HOOK", func() {
 			deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts,
 				corev1.VolumeMount{
 					Name:      hookVolumeName,
-					MountPath: provisioner.HookConfigDirectory,
+					MountPath: provisioner.ConfigDirectory,
 				},
 			)
 

--- a/tests/nfs_hook_test.go
+++ b/tests/nfs_hook_test.go
@@ -112,6 +112,7 @@ var _ = Describe("TEST NFS HOOK", func() {
 
 		backendPVName      = ""
 		hookConfigMapName  = "nfs-hook"
+		hookVolumeName     = "nfs-hook-vol"
 		hook               *nfshook.Hook
 		NFSProvisionerName = "openebs-nfs-provisioner"
 		openebsNamespace   = "openebs"
@@ -154,15 +155,26 @@ var _ = Describe("TEST NFS HOOK", func() {
 			)
 
 			By("updating the deployment")
-			nsEnv := corev1.EnvVar{
-				Name:  string(provisioner.NFSHookConfigMapName),
-				Value: hookConfigMapName,
-			}
-
-			deploy.Spec.Template.Spec.Containers[0].Env = append(
-				deploy.Spec.Template.Spec.Containers[0].Env,
-				nsEnv,
+			deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes,
+				corev1.Volume{
+					Name: hookVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: hookConfigMapName,
+							},
+						},
+					},
+				},
 			)
+
+			deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      hookVolumeName,
+					MountPath: provisioner.HookConfigDirectory,
+				},
+			)
+
 			_, err = Client.updateDeployment(deploy)
 			Expect(err).To(BeNil(), "while updating deployment %s/%s", openebsNamespace, NFSProvisionerName)
 
@@ -335,16 +347,30 @@ var _ = Describe("TEST NFS HOOK", func() {
 			Expect(err).To(BeNil(), "while fetching deployment %s/%s", openebsNamespace, NFSProvisionerName)
 
 			By("updating the provisioner deployment")
+			// Removing volumeMount
 			idx := 0
-			for idx < len(deploy.Spec.Template.Spec.Containers[0].Env) {
-				if deploy.Spec.Template.Spec.Containers[0].Env[idx].Name == string(provisioner.NFSHookConfigMapName) {
+			for idx < len(deploy.Spec.Template.Spec.Containers[0].VolumeMounts) {
+				if deploy.Spec.Template.Spec.Containers[0].VolumeMounts[idx].Name == hookVolumeName {
 					break
 				}
 				idx++
 			}
-			deploy.Spec.Template.Spec.Containers[0].Env = append(deploy.Spec.Template.Spec.Containers[0].Env[:idx], deploy.Spec.Template.Spec.Containers[0].Env[idx+1:]...)
+			deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts[:idx],
+				deploy.Spec.Template.Spec.Containers[0].VolumeMounts[idx+1:]...)
+
+			// Removing volume
+			idx = 0
+			for idx < len(deploy.Spec.Template.Spec.Volumes) {
+				if deploy.Spec.Template.Spec.Volumes[idx].Name == hookVolumeName {
+					break
+				}
+				idx++
+			}
+			deploy.Spec.Template.Spec.Volumes = append(deploy.Spec.Template.Spec.Volumes[:idx],
+				deploy.Spec.Template.Spec.Volumes[idx+1:]...)
+
 			_, err = Client.updateDeployment(deploy)
-			Expect(err).To(BeNil(), "while updateingupdating deployment %s/%s", openebsNamespace, NFSProvisionerName)
+			Expect(err).To(BeNil(), "while updating deployment %s/%s", openebsNamespace, NFSProvisionerName)
 
 			By("waiting for deployment rollout")
 			err = Client.waitForDeploymentRollout(OpenEBSNamespace, NFSProvisionerName)


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
NFS Provisioner uses configmap to load hook configuration. For this, the nfs-provisioner needs to use cluster config to download the configmap and configure the hook. To remove this dependency on cluster config, we can mount the hook configmap to nfs-provisioner at the pre-defined path(configured in nfs-provisioner) and use it to initialize the hook.

**What this PR does?**:
This PR updates the nfs-provisioner to load hook configuration from pre-defined file-path,`/etc/nfs-provisioner-hook/config`. This PR removes the old mechanism of loading hook config using env variable `OPENEBS_IO_NFS_HOOK_CONFIGMAP`. This PR also covers the following changes:
- updates [BDD test](https://github.com/openebs/dynamic-nfs-provisioner/blob/develop/tests/nfs_hook_test.go) to pass hook configuration using configmap via volumeMount
- updates [hook design document](https://github.com/openebs/dynamic-nfs-provisioner/blob/develop/docs/design/hooks.md) to incorporate these changes.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [x] (Optional) Does this PR change require updating NFS-Provisioner Chart? If yes, mention the Helm Chart PR https://github.com/openebs/dynamic-nfs-provisioner/pull/121
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 