### PR TITLE
fix(ci): build images before running sanity test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ on:
       - 'v*'
     paths-ignore:
       - 'deploy/helm/**'
+      - 'docs/**'
       - 'MAINTAINERS'
       - '*.md'
       - 'LICENSE'
@@ -53,7 +54,46 @@ jobs:
 
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
+  
+  sanity-test:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
+    runs-on: ubuntu-latest
+    needs: ['lint', 'unit-test']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.15
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: v1.24.0
+          kubernetes version: v1.20.13
+          start args: '--install-addons=false'
+
+      - name: Build provisioner-nfs image
+        run: make provisioner-nfs-image
+
+      - name: Build nfs-server-alpine image
+        run: make nfs-server-image
+
+      - name: Install NFS utils
+        run: |
+          sudo apt-get update && sudo apt-get install -y nfs-common
+
+      - name: Installation
+        run: |
+          ./tests/install-localpv.sh
+          ./tests/install-nfs-provisioner.sh
+
+      - name: Running sanity tests
+        run: make sanity-test
+  
   provisioner-nfs:
     runs-on: ubuntu-latest
     needs: ['lint', 'unit-test']
@@ -225,66 +265,6 @@ jobs:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}
 
-  sanity-test:
-    # to ignore builds on release
-    if: ${{ (github.event.ref_type != 'tag') }}
-    runs-on: ubuntu-latest
-    needs: ['lint', 'unit-test']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: v1.16.0
-          kubernetes version: v1.20.1
-
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: v0.5.1
-
-      - name: Build provisioner-nfs image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./buildscripts/provisioner-nfs/provisioner-nfs.Dockerfile
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: |
-            openebs/provisioner-nfs:ci
-
-      - name: Build nfs-server-alpine image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./nfs-server-container
-          file: nfs-server-container/Dockerfile
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: |
-            openebs/nfs-server-alpine:ci
-
-      - name: Install NFS utils
-        run: |
-          sudo apt-get update && sudo apt-get install -y nfs-common
-
-      - name: Installation
-        run: |
-          ./tests/install-localpv.sh
-          ./tests/install-nfs-provisioner.sh
-
-      - name: Running sanity tests
-        run: make sanity-test
-
   nfs-e2e:
     runs-on: ubuntu-latest
     steps:
@@ -310,4 +290,4 @@ jobs:
           load: false
           platforms: linux/amd64
           tags: |
-            ${{ env.IMAGE_ORG }}/nfs-e2e:ci           
+            ${{ env.IMAGE_ORG }}/nfs-e2e:ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.15
+
       - name: Set Image Org
         # sets the default IMAGE_ORG to openebs
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
     # to ignore builds on release
     if: ${{ (github.event.ref_type != 'tag') }}
     runs-on: ubuntu-latest
-    needs: ['provisioner-nfs', 'nfs-server']
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -245,10 +245,37 @@ jobs:
           minikube version: v1.16.0
           kubernetes version: v1.20.1
 
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.5.1
+
+      - name: Build provisioner-nfs image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./buildscripts/provisioner-nfs/provisioner-nfs.Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            openebs/provisioner-nfs:ci
+
+      - name: Build nfs-server-alpine image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./nfs-server-container
+          file: nfs-server-container/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            openebs/nfs-server-alpine:ci
+
       - name: Install NFS utils
         run: |
-          sudo apt-get update
-          sudo apt install nfs-common
+          sudo apt-get update && sudo apt-get install -y nfs-common
 
       - name: Installation
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,13 +69,6 @@ jobs:
         with:
           go-version: 1.15.15
 
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.2
-        with:
-          minikube version: v1.24.0
-          kubernetes version: v1.20.13
-          start args: '--install-addons=false'
-
       - name: Build provisioner-nfs image
         run: make provisioner-nfs-image
 
@@ -85,6 +78,13 @@ jobs:
       - name: Install NFS utils
         run: |
           sudo apt-get update && sudo apt-get install -y nfs-common
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: v1.24.0
+          kubernetes version: v1.20.13
+          start args: '--install-addons=false'
 
       - name: Installation
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,51 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
 
+  sanity-test:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
+    runs-on: ubuntu-latest
+    needs: ['lint', 'unit-test']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.15
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: v1.24.0
+          kubernetes version: v1.20.13
+          start args: '--install-addons=false'
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.5.1
+
+      - name: Build provisioner-nfs image
+        run: make provisioner-nfs-image
+
+      - name: Build nfs-server-alpine image
+        run: make nfs-server-image
+
+      - name: Install NFS utils
+        run: |
+          sudo apt-get update && sudo apt-get install -y nfs-common
+
+      - name: Installation
+        run: |
+          ./tests/install-localpv.sh
+          ./tests/install-nfs-provisioner.sh
+
+      - name: Running sanity tests
+        run: make sanity-test
+
   provisioner-nfs:
     runs-on: ubuntu-latest
     needs: ['lint', 'unit-test']
@@ -106,66 +151,6 @@ jobs:
           platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
           tags: |
             openebs/nfs-server-alpine:ci
-
-  sanity-test:
-    # to ignore builds on release
-    if: ${{ (github.event.ref_type != 'tag') }}
-    runs-on: ubuntu-latest
-    needs: ['lint', 'unit-test']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14.7
-
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: v1.16.0
-          kubernetes version: v1.20.1
-
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: v0.5.1
-
-      - name: Build provisioner-nfs image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./buildscripts/provisioner-nfs/provisioner-nfs.Dockerfile
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: |
-            openebs/provisioner-nfs:ci
-
-      - name: Build nfs-server-alpine image
-        uses: docker/build-push-action@v2
-        with:
-          context: ./nfs-server-container
-          file: nfs-server-container/Dockerfile
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: |
-            openebs/nfs-server-alpine:ci
-
-      - name: Install NFS utils
-        run: |
-          sudo apt-get update && sudo apt-get install -y nfs-common
-
-      - name: Installation
-        run: |
-          ./tests/install-localpv.sh
-          ./tests/install-nfs-provisioner.sh
-
-      - name: Running sanity tests
-        run: make sanity-test
 
   nfs-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,13 +66,6 @@ jobs:
         with:
           go-version: 1.15.15
 
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.2
-        with:
-          minikube version: v1.24.0
-          kubernetes version: v1.20.13
-          start args: '--install-addons=false'
-
       - name: Build provisioner-nfs image
         run: make provisioner-nfs-image
 
@@ -82,6 +75,13 @@ jobs:
       - name: Install NFS utils
         run: |
           sudo apt-get update && sudo apt-get install -y nfs-common
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.4.2
+        with:
+          minikube version: v1.24.0
+          kubernetes version: v1.20.13
+          start args: '--install-addons=false'
 
       - name: Installation
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -73,12 +73,6 @@ jobs:
           kubernetes version: v1.20.13
           start args: '--install-addons=false'
 
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: v0.5.1
-
       - name: Build provisioner-nfs image
         run: make provisioner-nfs-image
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.15
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -111,7 +111,7 @@ jobs:
     # to ignore builds on release
     if: ${{ (github.event.ref_type != 'tag') }}
     runs-on: ubuntu-latest
-    needs: ['provisioner-nfs', 'nfs-server']
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -127,13 +127,37 @@ jobs:
           minikube version: v1.16.0
           kubernetes version: v1.20.1
 
-      - name: Build and NFS-Provisioner image
-        run: make provisioner-nfs-image
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: v0.5.1
+
+      - name: Build provisioner-nfs image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./buildscripts/provisioner-nfs/provisioner-nfs.Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            openebs/provisioner-nfs:ci
+
+      - name: Build nfs-server-alpine image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./nfs-server-container
+          file: nfs-server-container/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            openebs/nfs-server-alpine:ci
 
       - name: Install NFS utils
         run: |
-          sudo apt-get update
-          sudo apt install nfs-common
+          sudo apt-get update && sudo apt-get install -y nfs-common
 
       - name: Installation
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     paths-ignore:
       - 'deploy/helm/**'
+      - 'docs/**'
       - 'MAINTAINERS'
       - '*.md'
       - 'LICENSE'

--- a/buildscripts/provisioner-nfs/Dockerfile
+++ b/buildscripts/provisioner-nfs/Dockerfile
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 #
-FROM alpine:3.11.5
+FROM alpine:3.12
 
 RUN apk add --no-cache \
     iproute2 \
@@ -51,4 +51,4 @@ LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-CMD ["/provisioner-nfs"]
+ENTRYPOINT ["/provisioner-nfs"]

--- a/buildscripts/provisioner-nfs/provisioner-nfs.Dockerfile
+++ b/buildscripts/provisioner-nfs/provisioner-nfs.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.14.7 as build
+FROM golang:1.15.15 as build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tests/nfs_claim_released_pv.go
+++ b/tests/nfs_claim_released_pv.go
@@ -57,6 +57,7 @@ var _ = Describe("TEST RECLAIM OF RELEASED NFS PV", func() {
 		// nfs provisioner values
 		openebsNamespace = "openebs"
 		scName           = "nfs-pv-sc-retain"
+		backendSCName    = "openebs-hostpath"
 		scReclaimPolicy  = corev1.PersistentVolumeReclaimRetain
 		scNfsServerType  = "kernel"
 		// nfsPv stores pv name created by application pvc
@@ -70,6 +71,10 @@ var _ = Describe("TEST RECLAIM OF RELEASED NFS PV", func() {
 				{
 					Name:  provisioner.KeyPVNFSServerType,
 					Value: scNfsServerType,
+				},
+				{
+					Name:  provisioner.KeyPVBackendStorageClass,
+					Value: backendSCName,
 				},
 			}
 

--- a/tests/nfs_sc_delayed_binding_test.go
+++ b/tests/nfs_sc_delayed_binding_test.go
@@ -61,6 +61,7 @@ var _ = Describe("TEST WaitForFirstConsumer binding mode for NFS PV", func() {
 
 		NFSScBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 		NFSScName        = "nfs-sc-waitforfirstconsumer"
+		backendSCName    = "openebs-hostpath"
 		scNfsServerType  = "kernel"
 	)
 
@@ -71,6 +72,10 @@ var _ = Describe("TEST WaitForFirstConsumer binding mode for NFS PV", func() {
 				{
 					Name:  provisioner.KeyPVNFSServerType,
 					Value: scNfsServerType,
+				},
+				{
+					Name:  provisioner.KeyPVBackendStorageClass,
+					Value: backendSCName,
 				},
 			}
 

--- a/tests/nfs_server_param_test.go
+++ b/tests/nfs_server_param_test.go
@@ -54,6 +54,7 @@ var _ = Describe("TEST NFS SERVER CONFIGURATION", func() {
 		openebsNamespace = "openebs"
 		nfsServerLabel   = "openebs.io/nfs-server"
 		scName           = "nfs-server-config-sc"
+		backendSCName    = "openebs-hostpath"
 		scNfsServerType  = "kernel"
 		scGraceTime      = "30"
 		scLeaseTime      = "30"
@@ -83,6 +84,10 @@ var _ = Describe("TEST NFS SERVER CONFIGURATION", func() {
 				{
 					Name:  provisioner.CustomServerConfig,
 					Value: scExportConfig,
+				},
+				{
+					Name:  provisioner.KeyPVBackendStorageClass,
+					Value: backendSCName,
 				},
 			}
 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The GitHub Actions CI runs `make sanity-test` against existing docker hub images. The images with the changes are not built correctly before running the sanity test. The sanity test does not produce results against the latest changes.

Additionally, the apt install for the nfs-common prerequisite will require interactive Y/N command if the nfs-common prerequisite is absent, and the install needs to go through. Added the `-y` flag to make the Y option non-interactive.

**What this PR does?**:
Build workflow: Both the provisioner-nfs and nfs-server-alpine image builds are added before the test run.
Pull Request workflow: The build for the nfs-server-alpine image is now added.

The Dockerfile file in buildscripts/provisioner-nfs/ directory now uses the same base image as provisioner-nfs.Dockerfile.
Changed the CMD directive to ENTRYPOINT directive in 'Dockerfile' file.

Go setup in GitHub actions is added to provisioner-nfs workflow.

Updated minikube action to latest version -- 2.4.2
Minikube used is now v1.24.0
Kubernetes version is now 1.20.13
Added flag to disable minikube storage-provisioner addon (nfs_claim_released_pv test, nfs_sc_delayed_binding_test.go, nfs_server_param_test.go now use openebs-hostpath BackendStorageClass instead of the default one)

Build and Pull Request workflow runs will be avoided for pushes to docs/ directory

The sanity-test now runs in parallel with the multi-arch build tests for the provisioner-nfs and nfs-server-alpine image.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Not manually verified.

**Any additional information for your reviewer?** :
The PR #125 depends on this.