### PR TITLE
feat(nfs-server): Add NodeAffinityList override to StorageClass

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openebs/maya v1.12.1-0.20210821080724-b90b5ede546d
+	github.com/openebs/maya v1.12.1-0.20211022052259-bd98908028af
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openebs/maya v1.12.1-0.20210821080724-b90b5ede546d h1:2X9S+8NjD24GwRUD5uW6qPEt/fwasvp2sJQrFPX6AS0=
-github.com/openebs/maya v1.12.1-0.20210821080724-b90b5ede546d/go.mod h1:J3DC3bzJ346KPhstfae02FfIpe8ikpk/4xV1iSqKLXQ=
+github.com/openebs/maya v1.12.1-0.20211022052259-bd98908028af h1:ybONzwC+k/zvgDcsCAatvT6u2j75tIVNYu5jX1pTmJE=
+github.com/openebs/maya v1.12.1-0.20211022052259-bd98908028af/go.mod h1:J3DC3bzJ346KPhstfae02FfIpe8ikpk/4xV1iSqKLXQ=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -152,6 +152,17 @@ func (p *Provisioner) Provision(ctx context.Context, opts pvController.Provision
 		return nil, pvController.ProvisioningNoChange, err
 	}
 
+	// Get the NodeAffinity from the Config if it is provided
+	// override the given NodeAffinity
+	nodeAffinityList, err := pvCASConfig.GetNodeAffinityLabels()
+	if err != nil {
+		return nil, pvController.ProvisioningNoChange, err
+	}
+
+	if len(nodeAffinityList.MatchExpressions) != 0 {
+		p.nodeAffinity = nodeAffinityList
+	}
+
 	// Validate nodeAffinity rules for scheduling
 	// There might be changes to node after deploying
 	// NFS Provisioner

--- a/provisioner/types.go
+++ b/provisioner/types.go
@@ -88,6 +88,7 @@ type VolumeConfig struct {
 	scName     string
 	options    map[string]interface{}
 	configData map[string]interface{}
+	configList map[string]interface{}
 }
 
 // GetVolumeConfigFn allows to plugin a custom function


### PR DESCRIPTION
Signed-off-by: Rid <rid@cylo.io>

**Why is this PR required? What issue does it fix?**:
Resolves #146 
This PR allows a user to add a node affinity list to the `cas.openebs.io/config` configmap in the `StorageClass`, which can override the `OPENEBS_IO_NFS_SERVER_NODE_AFFINITY` environment variable.

**What this PR does?**:
This PR allows users to specify affinity via the `StorageClass`, giving the user control of what nodes run the NFS server in a more dynamic way.

Sample `StorageClass`:
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: my-new-storageclass
  namespace: default
  annotations:
    openebs.io/cas-type: nfsrwx
    cas.openebs.io/config: |
      - name: NFSServerType
        value: "kernel"
      - name: BackendStorageClass
        value: "replicated-storage"
      - name: NodeAffinityLabels
        list:
          - node1
          - node2
provisioner: openebs.io/nfsrwx
reclaimPolicy: Delete
```

**Does this PR require any upgrade changes?**:
No.

**Checklist:**
- [x] Fixes #146 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [x] Commit has integration tests
