### PR TITLE
docs: update intro.md with FilePermissions cas-config

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -80,17 +80,24 @@ metadata:
         value: "kernel"
       - name: BackendStorageClass
         value: "openebs-hostpath"
-      #  LeaseTime defines the renewal period(in seconds) for client state
+      # LeaseTime defines the renewal period(in seconds) for client state
       #- name: LeaseTime
       #  value: 30
-      #  GraceTime defines the recovery period(in seconds) to reclaim locks
+      # GraceTime defines the recovery period(in seconds) to reclaim locks
       #- name: GraceTime
       #  value: 30
-      #  FSGID defines the group permissions of NFS Volume. If it is set
-      #  then non-root applications should add FSGID value under pod
-      #  Supplemental groups
-      #- name: FSGID
-      #  value: "120"
+      # FilePermissions defines the file ownership and mode specifications
+      # for the NFS server's shared filesystem volume.
+      # File permission changes are applied recursively if the root of the
+      # volume's filesystem does not match the specified value.
+      # Volume-specific file permission configuration can be specified by
+      # using the FilePermissions config key in the PVC YAML, instead of
+      # the StorageClass's.
+      #- name: FilePermissions
+      #  data:
+      #    UID: "1000"
+      #    GID: "2000"
+      #    mode: "0755"
 provisioner: openebs.io/nfsrwx
 reclaimPolicy: Delete
 ```


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
The intro.md doc page mentions the cas-config key 'FSGID'. The FSGID key is deprecated in favour of the FilePermissions key. While StorageClass yaml comments mention this, the intro.md representation might encourage a new user to use FSGID, instead of FilePermissions.

**What this PR does?**:
Changes comments in a sample StorageClass to contain FilePermissions cas-config key, and removes FSGID key.

**Does this PR require any upgrade changes?**:
Nope