### PR TITLE
fix(ci): correct release.yml syntax to use patterns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             ghcr.io/${{ env.IMAGE_ORG }}/provisioner-nfs
           tags: |
             type=raw,value=latest,enable=true
-            type=raw,value={{version}}
+            type=raw,pattern={{version}}
 
       - name: Print Tags
         run: |
@@ -141,7 +141,7 @@ jobs:
             ghcr.io/${{ env.IMAGE_ORG }}/nfs-server-alpine
           tags: |
             type=raw,value=latest,enable=true
-            type=raw,value={{version}}
+            type=raw,pattern={{version}}
 
       - name: Print Tags
         run: |


### PR DESCRIPTION
GitHub Actions file release.yml sets {{version}} as a value for docker/metadata-action jobs. This PR corrects it to use `pattern={{version}}` instead.